### PR TITLE
feat: curve impls dependent on copmile time features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,17 +7,34 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ff = { version = "0.2", package = "fff" }
-groupy = "0.3.0"
-paired = "0.18.0"
 rand_core = "0.5.1"
 rand = "0.7"
+smallbitvec = "2.4.0"
+
 # for ECIES
 chacha20poly1305 = "0.3"
 hkdf = "0.8"
 sha2 = "0.8"
 
-smallbitvec = "2.4.0"
-algebra = { git = "https://github.com/scipr-lab/zexe", features = ["bls12_377", "edwards_sw6"] }
-bls-crypto = { git = "https://github.com/celo-org/bls-zexe" }
+
+# bls12_381
+paired = { version = "0.18.0", optional = true }
+ff = { version = "0.2", package = "fff", optional = true }
+groupy = {version = "0.3.0", optional = true }
+
+
+# bls12_377
+
+algebra = { git = "https://github.com/scipr-lab/zexe", features = ["bls12_377", "edwards_sw6"], optional = true }
+bls-crypto = { git = "https://github.com/celo-org/bls-zexe", optional = true }
 #algebra_core = { git = "https://github.com/scipr-lab/zexe" }
+
+[features]
+default = ["bls12_377", "bls12_381"]
+bls12_377 = ["algebra", "bls-crypto"]
+bls12_381 = ["paired", "groupy", "ff"]
+
+[[example]]
+name = "tblind"
+path = "examples/tblind/main.rs"
+required-features = ["bls12_377"]

--- a/README.md
+++ b/README.md
@@ -54,6 +54,23 @@ fn interpolation() {
 }
 ```
 
+## Curve Implementations
+
+Curently there are two curves available, `BLS12 381` and `BLS 377`. By default they are enabled both, but you can select which one you want to use using
+the features `bls12_381` and `bls_377`.
+
+You can use them like this when adding the dependency to your `Cargo.toml` file.
+
+```toml
+# Only bls12_381
+threshold = { version = "0.1", default-features = false, features = ["bls12_381"] }
+# Only bls12_377
+threshold = { version = "0.1", default-features = false, features = ["bls12_377"] }
+# Both
+threshold = { version = "0.1" }
+```
+
+
 ## TODO:
 
 - [ ] doc for DKG

--- a/src/curve/mod.rs
+++ b/src/curve/mod.rs
@@ -1,6 +1,9 @@
 use std::error::Error;
 use std::fmt;
+
+#[cfg(feature = "bls12_381")]
 pub mod bls12381;
+#[cfg(feature = "bls12_377")]
 pub mod zexe;
 
 #[derive(Debug)]

--- a/src/dkg.rs
+++ b/src/dkg.rs
@@ -946,6 +946,7 @@ pub fn default_threshold(n: usize) -> usize {
     (((n as f64) * 2.0 / 3.0) + 1.0) as usize
 }
 
+#[cfg(feature = "bls12_381")]
 #[cfg(test)]
 pub mod tests {
     use super::*;

--- a/src/ecies.rs
+++ b/src/ecies.rs
@@ -135,6 +135,7 @@ where
     encrypt_with(to, msg, &mut thread_rng())
 }
 
+#[cfg(feature = "bls12_381")]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/poly.rs
+++ b/src/poly.rs
@@ -325,6 +325,7 @@ impl Error for InvalidRecovery {
     }
 }
 
+#[cfg(feature = "bls12_381")]
 #[cfg(test)]
 pub mod tests {
     use super::*;

--- a/src/sig/blind.rs
+++ b/src/sig/blind.rs
@@ -137,6 +137,7 @@ impl Error for BlindError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "bls12_381")]
     use crate::curve::bls12381::PairingCurve as PCurve;
 
     fn pair<B: SignatureScheme>() -> (B::Private, B::Public) {
@@ -147,11 +148,13 @@ mod tests {
         (private, public)
     }
 
+    #[cfg(feature = "bls12_381")]
     #[test]
     fn blind_g1() {
         blind_test::<BG1Scheme<PCurve>>();
     }
 
+    #[cfg(feature = "bls12_381")]
     #[test]
     fn blind_g2() {
         blind_test::<BG2Scheme<PCurve>>();

--- a/src/sig/bls.rs
+++ b/src/sig/bls.rs
@@ -144,6 +144,8 @@ impl Error for BLSError {
         None
     }
 }
+
+#[cfg(feature = "bls12_381")]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/sig/sig.rs
+++ b/src/sig/sig.rs
@@ -34,6 +34,8 @@ pub trait Scheme {
 /// signature scheme based on BLS, using the BLS12-381 curves.
 ///
 /// ```
+///  # #[cfg(feature = "bls12_381")]
+///  # {
 ///  use rand::prelude::*;
 ///  use threshold::sig::{SignatureScheme,Scheme};
 ///  use threshold::curve::bls12381::PairingCurve as PC;
@@ -48,6 +50,7 @@ pub trait Scheme {
 ///     Ok(_) => println!("signature is correct!"),
 ///     Err(e) => println!("signature is invalid: {}",e),
 ///  };
+/// # }
 /// ```
 /// Note signature scheme handles the format of the signature itself.
 pub trait SignatureScheme: Scheme {

--- a/src/sig/tblind.rs
+++ b/src/sig/tblind.rs
@@ -81,7 +81,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "bls12_381")]
     use crate::curve::bls12381::PairingCurve as PCurve;
+    #[cfg(feature = "bls12_377")]
     use crate::curve::zexe::PairingCurve as Zexe;
 
     use crate::Index;
@@ -100,21 +102,25 @@ mod tests {
         (shares, private.commit())
     }
 
+    #[cfg(feature = "bls12_377")]
     #[test]
     fn tblind_g1_zexe() {
         tblind_test::<G1Scheme<Zexe>>();
     }
 
+    #[cfg(feature = "bls12_377")]
     #[test]
     fn tblind_g1_zexe_unblind() {
         unblind_then_aggregate_test::<G1Scheme<Zexe>>();
     }
 
+    #[cfg(feature = "bls12_381")]
     #[test]
     fn tblind_g1() {
         tblind_test::<G1Scheme<PCurve>>();
     }
 
+    #[cfg(feature = "bls12_381")]
     #[test]
     fn tblind_g2() {
         tblind_test::<G2Scheme<PCurve>>();

--- a/src/sig/tbls.rs
+++ b/src/sig/tbls.rs
@@ -135,6 +135,7 @@ fn extract_index(sig: &[u8]) -> Result<(Index, Vec<u8>), TBLSError> {
 pub type TG1Scheme<C> = TScheme<bls::G1Scheme<C>>;
 pub type TG2Scheme<C> = TScheme<bls::G2Scheme<C>>;
 
+#[cfg(feature = "bls12_381")]
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
This allows not pulling in the dependencies of either curve implementation, when they are not needed.

By default both are still activated, so no change for downstream users.