### PR TITLE
(de)serialization for WASM

### DIFF
--- a/examples/blind.js
+++ b/examples/blind.js
@@ -15,14 +15,14 @@ const blind_msg = blinded_msg.message
 // Generate a keypair for the service
 const service_seed = crypto.randomBytes(32)
 const keypair = threshold.keygen(service_seed)
-const private_key = keypair.privateKeyPtr
-const public_key = keypair.publicKeyPtr
+const private_key = keypair.privateKey
+const public_key = keypair.publicKey
 
 // Sign the user's blinded message with the service's private key
 const blind_sig = threshold.sign(private_key, blind_msg)
 
 // User unblinds the signature with this scalar
-const unblinded_sig = threshold.unblind(blind_sig, blinded_msg.blindingFactorPtr)
+const unblinded_sig = threshold.unblind(blind_sig, blinded_msg.blindingFactor)
 
 // User verifies the unblinded signature on his unblinded message
 // (this throws on error)

--- a/examples/tblind.js
+++ b/examples/tblind.js
@@ -16,13 +16,13 @@ const blindedMessage = blinded.message
 const t = 3;
 const n = 4;
 const keys = threshold.thresholdKeygen(n, t, crypto.randomBytes(32))
-const shares = keys.sharesPtr
-const polynomial = keys.polynomialPtr
+const shares = keys.shares
+const polynomial = keys.polynomial
 
 // each of these shares proceed to sign teh blinded sig
 let sigs = []
 for (let i = 0 ; i < keys.numShares(); i++ ) {
-    const sig = threshold.partialSign(keys.getSharePtr(i), blindedMessage)
+    const sig = threshold.partialSign(keys.getShare(i), blindedMessage)
     sigs.push(sig)
 }
 
@@ -34,10 +34,10 @@ for (const sig of sigs) {
 const blindSig = threshold.combine(t, flattenSigsArray(sigs))
 
 // User unblinds the combined threshold signature with his scalar
-const sig = threshold.unblind(blindSig, blinded.blindingFactorPtr)
+const sig = threshold.unblind(blindSig, blinded.blindingFactor)
 
 // User verifies the unblinded signautre on his unblinded message
-threshold.verify(keys.thresholdPublicKeyPtr, msg, sig)
+threshold.verify(keys.thresholdPublicKey, msg, sig)
 console.log("Verification successful")
 
 function flattenSigsArray(sigs) {

--- a/examples/tblind/node.rs
+++ b/examples/tblind/node.rs
@@ -1,9 +1,9 @@
 use crate::board::Board;
 use crate::curve::{KeyCurve, PrivateKey, PublicKey, Scheme};
-use std::error::Error;
 use blind_threshold_bls::dkg;
 use blind_threshold_bls::sig::ThresholdScheme;
 use blind_threshold_bls::*;
+use std::error::Error;
 /// Node holds the logic of a participants, for the different phases of the
 /// example.
 pub struct Node {

--- a/examples/tblind/orchestrator.rs
+++ b/examples/tblind/orchestrator.rs
@@ -1,11 +1,11 @@
 use crate::board::Board;
 use crate::curve::{KeyCurve, PrivateKey, PublicKey, Scheme};
 use crate::node::Node;
-use rand::prelude::*;
-use std::error::Error;
 use blind_threshold_bls::dkg;
 use blind_threshold_bls::sig::*;
 use blind_threshold_bls::*;
+use rand::prelude::*;
+use std::error::Error;
 
 pub struct Orchestrator {
     thr: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+use std::convert::TryInto;
+
 pub mod curve;
 pub mod dkg;
 pub mod ecies;
@@ -17,4 +19,65 @@ pub type DistPublic<C> = poly::PublicPoly<C>;
 pub struct Share<S: group::Scalar> {
     index: Index,
     private: S,
+}
+
+impl<S: group::Scalar> Share<S> {
+    pub fn new(index: Index, private: S) -> Self {
+        Self { index, private }
+    }
+}
+
+impl<S> Encodable for Share<S>
+where
+    S: Scalar,
+{
+    fn marshal_len() -> usize {
+        <S as Encodable>::marshal_len() + std::mem::size_of::<Index>()
+    }
+
+    fn marshal(&self) -> Vec<u8> {
+        let mut bytes = self.index.to_le_bytes().to_vec();
+        let pk_bytes = self.private.marshal();
+        bytes.extend_from_slice(&pk_bytes);
+        bytes
+    }
+
+    fn unmarshal(&mut self, data: &[u8]) -> Result<(), Box<dyn std::error::Error>> {
+        let (int_bytes, rest) = data.split_at(std::mem::size_of::<Index>());
+        let index = u32::from_le_bytes(int_bytes.try_into()?);
+
+        self.index = index;
+        self.private.unmarshal(rest)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "bls12_377")]
+mod tests {
+    use super::*;
+    use group::Encodable;
+
+    use curve::zexe::Scalar;
+
+    #[test]
+    fn share_serialization() {
+        let rng = &mut rand::thread_rng();
+        for _ in 0..100 {
+            let mut pk = Scalar::new();
+            pk.pick(rng);
+
+            let share = Share {
+                index: rand::random(),
+                private: pk,
+            };
+
+            let ser = share.marshal();
+            let mut de = Share::new(0, Scalar::new());
+            de.unmarshal(&ser).unwrap();
+
+            assert_eq!(share, de);
+        }
+    }
 }

--- a/src/poly.rs
+++ b/src/poly.rs
@@ -1,6 +1,8 @@
 use crate::group::{Curve, Element, Point, Scalar};
+use crate::Encodable;
 use rand_core::RngCore;
 use std::collections::HashMap;
+use std::convert::TryInto;
 use std::error::Error;
 use std::fmt;
 use std::marker::PhantomData;
@@ -36,6 +38,44 @@ where
 pub struct Poly<Var: Scalar, Coeff: Element<Var>> {
     c: Vec<Coeff>,
     phantom: PhantomData<Var>,
+}
+
+impl<Var, Coeff> Encodable for Poly<Var, Coeff>
+where
+    Var: Scalar,
+    Coeff: Element<Var> + Encodable,
+{
+    // This cannot be known as the Poly is a variable length data structure.
+    fn marshal_len() -> usize {
+        unreachable!()
+    }
+
+    fn marshal(&self) -> Vec<u8> {
+        let mut bytes = self.c.len().to_le_bytes().to_vec();
+        for coeff in &self.c {
+            let coeff_bytes = coeff.marshal();
+            bytes.extend_from_slice(&coeff_bytes);
+        }
+        bytes
+    }
+
+    fn unmarshal(&mut self, data: &[u8]) -> Result<(), Box<dyn std::error::Error>> {
+        let (int_bytes, rest) = data.split_at(std::mem::size_of::<usize>());
+        let num_coeffs = usize::from_le_bytes(int_bytes.try_into()?);
+
+        let mut coeffs = Vec::new();
+
+        let size = Coeff::marshal_len();
+        for i in 0..num_coeffs {
+            let mut coeff = Coeff::new();
+            coeff.unmarshal(&rest[i * size..(i + 1) * size])?;
+            coeffs.push(coeff);
+        }
+
+        self.c = coeffs;
+
+        Ok(())
+    }
 }
 
 impl<X, C> Poly<X, C>
@@ -341,6 +381,18 @@ pub mod tests {
     }
 
     #[test]
+    fn serialization() {
+        let p = Poly::<Sc, Sc>::new(10);
+
+        let ser = p.marshal();
+
+        let mut de = Poly::<Sc, Sc>::new(0);
+        de.unmarshal(&ser).unwrap();
+
+        assert_eq!(p, de);
+    }
+
+    #[test]
     fn full_interpolation() {
         let degree = 4;
         let threshold = degree + 1;
@@ -422,7 +474,6 @@ pub mod tests {
         exp.add(&p2.c[0]);
         assert_eq!(exp, p3.c[0]);
     }
-
     #[test]
     fn mul() {
         let d = 1;

--- a/src/sig/blind.rs
+++ b/src/sig/blind.rs
@@ -12,6 +12,12 @@ use std::marker::PhantomData;
 /// In this blind signature scheme, the token is simply a field element.
 pub struct Token<S: Scalar>(S);
 
+impl<S: Scalar> Token<S> {
+    pub fn new() -> Self {
+        Self(S::new())
+    }
+}
+
 impl<S> Encodable for Token<S>
 where
     S: Scalar,


### PR DESCRIPTION
- Implements `Encodable` for `poly`, `token` and `share`. Note that due to `Poly` being a variable length data structure, we cannot know its marshalled length only from the type, and as such it is left `unimplemented`.

- Using these, the pointers are no longer used in WASM. The functions instead take opaque buffers which they internally try to deserialize.

Closes https://github.com/celo-org/celo-threshold-bls-rs/issues/10, since when a variable is loaded on Javascript via the getter, it is fetched as a Uint8Array. It can then be written to anywhere desired.