### PR TITLE
Key Serialization FFI

### DIFF
--- a/ffi/threshold.h
+++ b/ffi/threshold.h
@@ -61,6 +61,8 @@ typedef Private PrivateKey;
 
 typedef Public PublicKey;
 
+typedef Signature Signature;
+
 /**
  * Given a message and a seed, it will blind it and return the blinded message
  *
@@ -89,6 +91,16 @@ bool combine(uintptr_t threshold, const Buffer *signatures, Buffer *asig);
 bool deserialize_privkey(const uint8_t *privkey_buf, PrivateKey **privkey);
 
 bool deserialize_pubkey(const uint8_t *pubkey_buf, PublicKey **pubkey);
+
+bool deserialize_sig(const uint8_t *sig_buf, Signature **sig);
+
+void destroy_privkey(PrivateKey *private_key);
+
+void destroy_pubkey(PublicKey *public_key);
+
+void destroy_sig(Signature *signature);
+
+void free_vector(uint8_t *bytes, uintptr_t len);
 
 /**
  * Generates a single private key from the provided seed.
@@ -136,6 +148,8 @@ const PublicKey *public_key_ptr(const Keypair *keypair);
 void serialize_privkey(const PrivateKey *privkey, uint8_t **privkey_buf);
 
 void serialize_pubkey(const PublicKey *pubkey, uint8_t **pubkey_buf);
+
+void serialize_sig(const Signature *sig, uint8_t **sig_buf);
 
 /**
  * Gets the `index`'th share corresponding to the provided `Keys` pointer

--- a/ffi/threshold.h
+++ b/ffi/threshold.h
@@ -1,0 +1,169 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+/**
+ * A BLS12-377 Keypair
+ */
+typedef struct Keypair Keypair;
+
+typedef struct Keys Keys;
+
+/**
+ * A polynomial that is using a scalar for the variable x and a generic
+ * element for the coefficients. The coefficients must be able to multiply
+ * the type of the variable, which is always a scalar.
+ */
+typedef struct Poly_PrivateKey__PublicKey Poly_PrivateKey__PublicKey;
+
+typedef struct Share_PrivateKey Share_PrivateKey;
+
+/**
+ * Blinding a message before requesting a signature requires the usage of a
+ * private blinding factor that is called a Token. To unblind the signature
+ * afterwards, one needs the same token as what the blinding method returned.
+ * In this blind signature scheme, the token is simply a field element.
+ */
+typedef struct Token_PrivateKey Token_PrivateKey;
+
+/**
+ * A blinded message along with the blinding_factor used to produce it
+ */
+typedef struct {
+  /**
+   * The resulting blinded message
+   */
+  Buffer message;
+  /**
+   * The blinding_factor which was used to generate the blinded message. This will be used
+   * to unblind the signature received on the blinded message to a valid signature
+   * on the unblinded message
+   */
+  Token_PrivateKey blinding_factor;
+} BlindedMessage;
+
+typedef Private PrivateKey;
+
+typedef Public PublicKey;
+
+/**
+ * Given a message and a seed, it will blind it and return the blinded message
+ *
+ * * message: A cleartext message which you want to blind
+ * * seed: A 32 byte seed for randomness. You can get one securely via `crypto.randomBytes(32)`
+ * * blinded_message: Pointer to the memory where the blinded message will be written to
+ *
+ * The `BlindedMessage.blinding_factor` should be saved for unblinding any
+ * signatures on `BlindedMessage.message`
+ *
+ * # Safety
+ * - If the same seed is used twice, the blinded result WILL be the same
+ *
+ * Returns true if successful, otherwise false.
+ */
+void blind(const Buffer *message, const Buffer *seed, BlindedMessage *blinded_message);
+
+/**
+ * Combines a flattened vector of partial signatures to a single threshold signature
+ *
+ * # Safety
+ * - This function does not check if the signatures are valid!
+ */
+bool combine(uintptr_t threshold, const Buffer *signatures, Buffer *asig);
+
+bool deserialize_privkey(const uint8_t *privkey_buf, PrivateKey **privkey);
+
+bool deserialize_pubkey(const uint8_t *pubkey_buf, PublicKey **pubkey);
+
+/**
+ * Generates a single private key from the provided seed.
+ *
+ * # Safety
+ *
+ * The seed MUST be at least 32 bytes long
+ */
+void keygen(const Buffer *seed, Keypair *keypair);
+
+/**
+ * Gets the number of shares corresponding to the provided `Keys` pointer
+ */
+uintptr_t num_shares(const Keys *keys);
+
+/**
+ * Signs the message with the provided **share** of the private key and returns the **partial**
+ * signature.
+ */
+bool partial_sign(const Share_PrivateKey *share, const Buffer *message, Buffer *signature);
+
+/**
+ * Verifies a partial signature against the public key corresponding to the secret shared
+ * polynomial.
+ */
+bool partial_verify(const Poly_PrivateKey__PublicKey *polynomial,
+                    const Buffer *blinded_message,
+                    const Buffer *sig);
+
+/**
+ * Gets a pointer to the polynomial corresponding to the provided `Keys` pointer
+ */
+const Poly_PrivateKey__PublicKey *polynomial_ptr(const Keys *keys);
+
+/**
+ * Gets a pointer to the private key corresponding to the provided `KeyPair` pointer
+ */
+const PrivateKey *private_key_ptr(const Keypair *keypair);
+
+/**
+ * Gets a pointer to the public key corresponding to the provided `KeyPair` pointer
+ */
+const PublicKey *public_key_ptr(const Keypair *keypair);
+
+void serialize_privkey(const PrivateKey *privkey, uint8_t **privkey_buf);
+
+void serialize_pubkey(const PublicKey *pubkey, uint8_t **pubkey_buf);
+
+/**
+ * Gets the `index`'th share corresponding to the provided `Keys` pointer
+ */
+const Share_PrivateKey *share_ptr(const Keys *keys, uintptr_t index);
+
+/**
+ * Signs the message with the provided private key and returns the signature
+ *
+ * # Throws
+ *
+ * - If signing fails
+ */
+bool sign(const PrivateKey *private_key, const Buffer *message, Buffer *signature);
+
+/**
+ * Gets a pointer to the threshold public key corresponding to the provided `Keys` pointer
+ */
+const PublicKey *threshold_public_key_ptr(const Keys *keys);
+
+/**
+ * Given a blinded signature and a blinding_factor used for blinding, it returns the signature
+ * unblinded
+ *
+ * * blinded_signature: A message which has been blinded or a blind signature
+ * * blinding_factor: The blinding_factor used to blind the message
+ * * unblinded_signature: Pointer to the memory where the unblinded signature will be written to
+ *
+ * Returns true if successful, otherwise false.
+ */
+bool unblind(const Buffer *blinded_signature,
+             const Token_PrivateKey *blinding_factor,
+             Buffer *unblinded_signature);
+
+/**
+ * Verifies the signature after it has been unblinded. Users will call this on the
+ * threshold signature against the full public key
+ *
+ * * public_key: The public key used to sign the message
+ * * message: The message which was signed
+ * * signature: The signature which was produced on the message
+ *
+ * Returns true if successful, otherwise false.
+ */
+bool verify(const PublicKey *public_key, const Buffer *message, const Buffer *signature);

--- a/ffi/threshold.h
+++ b/ffi/threshold.h
@@ -28,6 +28,20 @@ typedef struct Share_PrivateKey Share_PrivateKey;
 typedef struct Token_PrivateKey Token_PrivateKey;
 
 /**
+ * Data structure which is used to store buffers of varying length
+ */
+typedef struct {
+  /**
+   * Pointer to the message
+   */
+  const uint8_t *ptr;
+  /**
+   * The length of the buffer
+   */
+  int len;
+} Buffer;
+
+/**
  * A blinded message along with the blinding_factor used to produce it
  */
 typedef struct {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -236,6 +236,60 @@ pub extern "C" fn combine(threshold: usize, signatures: *const Buffer, asig: *mu
 }
 
 ///////////////////////////////////////////////////////////////////////////
+// Serialization
+///////////////////////////////////////////////////////////////////////////
+
+#[no_mangle]
+pub extern "C" fn deserialize_public_key(
+    pubkey_buf: *const u8,
+    pubkey: *mut *mut PublicKey,
+) -> bool {
+    let obj = PublicKey::new();
+    deserialize(pubkey_buf, pubkey, obj)
+}
+
+#[no_mangle]
+pub extern "C" fn deserialize_private_key(
+    privkey_buf: *const u8,
+    privkey: *mut *mut PrivateKey,
+) -> bool {
+    let obj = PrivateKey::new();
+    deserialize(privkey_buf, privkey, obj)
+}
+
+#[no_mangle]
+pub extern "C" fn serialize_public_key(pubkey: *const PublicKey, pubkey_buf: *mut *mut u8) {
+    serialize(pubkey, pubkey_buf)
+}
+
+#[no_mangle]
+pub extern "C" fn serialize_private_key(privkey: *const PrivateKey, privkey_buf: *mut *mut u8) {
+    serialize(privkey, privkey_buf)
+}
+
+fn deserialize<T: Encodable>(in_buf: *const u8, out: *mut *mut T, mut obj: T) -> bool {
+    let buf = unsafe { std::slice::from_raw_parts(in_buf, T::marshal_len()) };
+
+    if let Err(_) = obj.unmarshal(&buf) {
+        return false;
+    }
+
+    unsafe { *out = Box::into_raw(Box::new(obj)) };
+
+    true
+}
+
+fn serialize<T: Encodable>(in_obj: *const T, out_bytes: *mut *mut u8) {
+    let obj = unsafe { &*in_obj };
+    let mut marshalled = obj.marshal();
+
+    unsafe {
+        *out_bytes = marshalled.as_mut_ptr();
+    };
+    std::mem::forget(marshalled);
+}
+
+///////////////////////////////////////////////////////////////////////////
 // Helpers
 //
 // These should be exposed behind a helper module and should not be made part
@@ -481,5 +535,71 @@ mod tests {
             &unblinded,
         );
         assert!(ret);
+    }
+
+    #[test]
+    fn private_key_serialization() {
+        let seed = b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+        let mut keypair = MaybeUninit::<Keypair>::uninit();
+        keygen(&Buffer::from(&seed[..]), keypair.as_mut_ptr());
+        let keypair = unsafe { keypair.assume_init() };
+
+        let private_key_ptr = private_key_ptr(&keypair);
+        let private_key = unsafe { &*private_key_ptr };
+        let marshalled = private_key.marshal();
+
+        let mut privkey_buf = MaybeUninit::<*mut u8>::uninit();
+
+        serialize_private_key(private_key_ptr, privkey_buf.as_mut_ptr());
+
+        let message = unsafe {
+            std::slice::from_raw_parts(privkey_buf.assume_init(), PrivateKey::marshal_len())
+        };
+        assert_eq!(marshalled, message);
+
+        let mut unmarshalled = PrivateKey::new();
+        unmarshalled.unmarshal(&message).unwrap();
+        assert_eq!(&unmarshalled, private_key);
+
+        let mut de = MaybeUninit::<*mut PrivateKey>::uninit();
+        deserialize_private_key(&message[0] as *const u8, de.as_mut_ptr());
+        let de = unsafe { &*de.assume_init() };
+
+        assert_eq!(private_key, de);
+    }
+
+    #[test]
+    fn public_key_serialization() {
+        let seed = b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+        let mut keypair = MaybeUninit::<Keypair>::uninit();
+        keygen(&Buffer::from(&seed[..]), keypair.as_mut_ptr());
+        let keypair = unsafe { keypair.assume_init() };
+
+        let public_key_ptr = public_key_ptr(&keypair);
+        let public_key = unsafe { &*public_key_ptr };
+
+        let marshalled = public_key.marshal();
+
+        let mut pubkey_buf = MaybeUninit::<*mut u8>::uninit();
+
+        serialize_public_key(public_key_ptr, pubkey_buf.as_mut_ptr());
+
+        // the serialized result
+        let message = unsafe {
+            std::slice::from_raw_parts(pubkey_buf.assume_init(), PublicKey::marshal_len())
+        };
+        assert_eq!(marshalled, message);
+
+        let mut unmarshalled = PublicKey::new();
+        unmarshalled.unmarshal(&message).unwrap();
+        assert_eq!(&unmarshalled, public_key);
+
+        let mut de = MaybeUninit::<*mut PublicKey>::uninit();
+        deserialize_public_key(&message[0] as *const u8, de.as_mut_ptr());
+        let de = unsafe { &*de.assume_init() };
+
+        assert_eq!(public_key, de);
     }
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -239,7 +239,7 @@ pub extern "C" fn combine(threshold: usize, signatures: *const Buffer, asig: *mu
 // Serialization
 ///////////////////////////////////////////////////////////////////////////
 
-#[no_mangle]
+// #[no_mangle]
 pub extern "C" fn deserialize_public_key(
     pubkey_buf: *const u8,
     pubkey: *mut *mut PublicKey,
@@ -248,7 +248,7 @@ pub extern "C" fn deserialize_public_key(
     deserialize(pubkey_buf, pubkey, obj)
 }
 
-#[no_mangle]
+// #[no_mangle]
 pub extern "C" fn deserialize_private_key(
     privkey_buf: *const u8,
     privkey: *mut *mut PrivateKey,
@@ -257,12 +257,12 @@ pub extern "C" fn deserialize_private_key(
     deserialize(privkey_buf, privkey, obj)
 }
 
-#[no_mangle]
+// #[no_mangle]
 pub extern "C" fn serialize_public_key(pubkey: *const PublicKey, pubkey_buf: *mut *mut u8) {
     serialize(pubkey, pubkey_buf)
 }
 
-#[no_mangle]
+// #[no_mangle]
 pub extern "C" fn serialize_private_key(privkey: *const PrivateKey, privkey_buf: *mut *mut u8) {
     serialize(privkey, privkey_buf)
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -239,17 +239,14 @@ pub extern "C" fn combine(threshold: usize, signatures: *const Buffer, asig: *mu
 // Serialization
 ///////////////////////////////////////////////////////////////////////////
 
-// #[no_mangle]
-pub extern "C" fn deserialize_public_key(
-    pubkey_buf: *const u8,
-    pubkey: *mut *mut PublicKey,
-) -> bool {
+#[no_mangle]
+pub extern "C" fn deserialize_pubkey(pubkey_buf: *const u8, pubkey: *mut *mut PublicKey) -> bool {
     let obj = PublicKey::new();
     deserialize(pubkey_buf, pubkey, obj)
 }
 
-// #[no_mangle]
-pub extern "C" fn deserialize_private_key(
+#[no_mangle]
+pub extern "C" fn deserialize_privkey(
     privkey_buf: *const u8,
     privkey: *mut *mut PrivateKey,
 ) -> bool {
@@ -257,13 +254,13 @@ pub extern "C" fn deserialize_private_key(
     deserialize(privkey_buf, privkey, obj)
 }
 
-// #[no_mangle]
-pub extern "C" fn serialize_public_key(pubkey: *const PublicKey, pubkey_buf: *mut *mut u8) {
+#[no_mangle]
+pub extern "C" fn serialize_pubkey(pubkey: *const PublicKey, pubkey_buf: *mut *mut u8) {
     serialize(pubkey, pubkey_buf)
 }
 
-// #[no_mangle]
-pub extern "C" fn serialize_private_key(privkey: *const PrivateKey, privkey_buf: *mut *mut u8) {
+#[no_mangle]
+pub extern "C" fn serialize_privkey(privkey: *const PrivateKey, privkey_buf: *mut *mut u8) {
     serialize(privkey, privkey_buf)
 }
 
@@ -551,7 +548,7 @@ mod tests {
 
         let mut privkey_buf = MaybeUninit::<*mut u8>::uninit();
 
-        serialize_private_key(private_key_ptr, privkey_buf.as_mut_ptr());
+        serialize_privkey(private_key_ptr, privkey_buf.as_mut_ptr());
 
         let message = unsafe {
             std::slice::from_raw_parts(privkey_buf.assume_init(), PrivateKey::marshal_len())
@@ -563,7 +560,7 @@ mod tests {
         assert_eq!(&unmarshalled, private_key);
 
         let mut de = MaybeUninit::<*mut PrivateKey>::uninit();
-        deserialize_private_key(&message[0] as *const u8, de.as_mut_ptr());
+        deserialize_privkey(&message[0] as *const u8, de.as_mut_ptr());
         let de = unsafe { &*de.assume_init() };
 
         assert_eq!(private_key, de);
@@ -584,7 +581,7 @@ mod tests {
 
         let mut pubkey_buf = MaybeUninit::<*mut u8>::uninit();
 
-        serialize_public_key(public_key_ptr, pubkey_buf.as_mut_ptr());
+        serialize_pubkey(public_key_ptr, pubkey_buf.as_mut_ptr());
 
         // the serialized result
         let message = unsafe {
@@ -597,7 +594,7 @@ mod tests {
         assert_eq!(&unmarshalled, public_key);
 
         let mut de = MaybeUninit::<*mut PublicKey>::uninit();
-        deserialize_public_key(&message[0] as *const u8, de.as_mut_ptr());
+        deserialize_pubkey(&message[0] as *const u8, de.as_mut_ptr());
         let de = unsafe { &*de.assume_init() };
 
         assert_eq!(public_key, de);


### PR DESCRIPTION
This will allow loading a buffer in memory as a privkey or pubkey.

NOTE: The pubkey serialization and deserialization functions are named slightly awkwardly to avoid a naming collision with the serialization functions from BLS-Crypto which causes runtime errors.