### PR TITLE
Trait Simplification & Concrete Error Types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1202,6 +1202,7 @@ dependencies = [
  "serde",
  "sha2",
  "static_assertions",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/dkg-cli/src/bin/coordinator.rs
+++ b/crates/dkg-cli/src/bin/coordinator.rs
@@ -10,7 +10,7 @@ use std::process;
 
 use threshold_bls::{
     curve::zexe::{self as bls12_377, PairingCurve as BLS12_377},
-    sig::tblind::G2Scheme,
+    sig::bls::G2Scheme,
 };
 
 // TODO: In the future, we may want to make the CLI work with both G1

--- a/crates/dkg-cli/src/bin/dkg.rs
+++ b/crates/dkg-cli/src/bin/dkg.rs
@@ -8,7 +8,7 @@ use std::process;
 
 use threshold_bls::{
     curve::zexe::{self as bls12_377, PairingCurve as BLS12_377},
-    sig::tblind::G2Scheme,
+    sig::bls::G2Scheme,
 };
 
 // TODO: In the future, we may want to make the CLI work with both G1

--- a/crates/dkg-core/src/node.rs
+++ b/crates/dkg-core/src/node.rs
@@ -143,7 +143,7 @@ mod tests {
         curve::zexe::{self as bls12_377, PairingCurve as BLS12_377},
         group::{Element, Encodable, Point},
         sig::{
-            tblind::{G1Scheme, G2Scheme},
+            bls::{G1Scheme, G2Scheme},
             Blinder, Scheme, ThresholdScheme,
         },
         Index,

--- a/crates/threshold-bls-ffi/src/ffi.rs
+++ b/crates/threshold-bls-ffi/src/ffi.rs
@@ -110,7 +110,7 @@ pub extern "C" fn verify(
 
     // checks the signature on the message hash
     let signature = <&[u8]>::from(unsafe { &*signature });
-    match SigScheme::verify(public_key, &msg_hash, signature) {
+    match <SigScheme as SignatureScheme>::verify(public_key, &msg_hash, signature) {
         Ok(_) => true,
         Err(_) => false,
     }

--- a/crates/threshold-bls-ffi/src/wasm.rs
+++ b/crates/threshold-bls-ffi/src/wasm.rs
@@ -92,7 +92,7 @@ pub fn verify(public_key_buf: &[u8], message: &[u8], signature: &[u8]) -> Result
     let msg_hash = msg_hash.marshal();
 
     // checks the signature on the message hash
-    SigScheme::verify(&public_key, &msg_hash, &signature)
+    <SigScheme as SignatureScheme>::verify(&public_key, &msg_hash, &signature)
         .map_err(|err| JsValue::from_str(&format!("signature verification failed: {}", err)))
 }
 

--- a/crates/threshold-bls-ffi/src/wasm.rs
+++ b/crates/threshold-bls-ffi/src/wasm.rs
@@ -8,21 +8,14 @@ use threshold_bls::{
     curve::zexe::PairingCurve as Bls12_377,
     group::{Element, Encodable, Point},
     poly::Poly,
-    sig::{
-        blind::{BG2Scheme, Token},
-        tblind::G2Scheme,
-        Blinder, Scheme, SignatureScheme, ThresholdScheme,
-    },
+    sig::{blind::Token, bls::G2Scheme, Blinder, Scheme, SignatureScheme, ThresholdScheme},
     Index, Share,
 };
 
-// TODO(gakonst): Make these bindings more generic. Maybe a macro is needed here since
-// wasm-bindgen does not support generics
-type BlindThresholdSigs = G2Scheme<Bls12_377>;
-type BlindSigs = BG2Scheme<Bls12_377>;
-type PublicKey = <BlindThresholdSigs as Scheme>::Public;
-type PrivateKey = <BlindThresholdSigs as Scheme>::Private;
-type Signature = <BlindThresholdSigs as Scheme>::Signature;
+type SigScheme = G2Scheme<Bls12_377>;
+type PublicKey = <SigScheme as Scheme>::Public;
+type PrivateKey = <SigScheme as Scheme>::Private;
+type Signature = <SigScheme as Scheme>::Signature;
 type Result<T> = std::result::Result<T, JsValue>;
 
 ///////////////////////////////////////////////////////////////////////////
@@ -45,7 +38,7 @@ pub fn blind(message: Vec<u8>, seed: &[u8]) -> BlindedMessage {
     let mut rng = get_rng(&seed);
 
     // blind the message with this randomness
-    let (blinding_factor, blinded_message) = BlindThresholdSigs::blind(&message, &mut rng);
+    let (blinding_factor, blinded_message) = SigScheme::blind(&message, &mut rng);
 
     // return the message and the blinding_factor used for blinding
     BlindedMessage {
@@ -72,7 +65,7 @@ pub fn unblind(blinded_signature: &[u8], blinding_factor_buf: &[u8]) -> Result<V
             JsValue::from_str(&format!("could not unmarshal blinding factor {}", err))
         })?;
 
-    BlindThresholdSigs::unblind(&blinding_factor, blinded_signature)
+    SigScheme::unblind(&blinding_factor, blinded_signature)
         .map_err(|err| JsValue::from_str(&format!("could not unblind signature {}", err)))
 }
 
@@ -99,7 +92,7 @@ pub fn verify(public_key_buf: &[u8], message: &[u8], signature: &[u8]) -> Result
     let msg_hash = msg_hash.marshal();
 
     // checks the signature on the message hash
-    BlindThresholdSigs::verify(&public_key, &msg_hash, &signature)
+    SigScheme::verify(&public_key, &msg_hash, &signature)
         .map_err(|err| JsValue::from_str(&format!("signature verification failed: {}", err)))
 }
 
@@ -119,7 +112,7 @@ pub fn sign(private_key_buf: &[u8], message: &[u8]) -> Result<Vec<u8>> {
         .unmarshal(&private_key_buf)
         .map_err(|err| JsValue::from_str(&format!("could not unmarshal private key {}", err)))?;
 
-    BlindSigs::sign(&private_key, &message)
+    SigScheme::sign(&private_key, &message)
         .map_err(|err| JsValue::from_str(&format!("could not sign message: {}", err)))
 }
 
@@ -139,7 +132,7 @@ pub fn partial_sign(share_buf: &[u8], message: &[u8]) -> Result<Vec<u8>> {
         JsValue::from_str(&format!("could not unmarshal private key share {}", err))
     })?;
 
-    BlindThresholdSigs::partial_sign(&share, &message)
+    SigScheme::partial_sign(&share, &message)
         .map_err(|err| JsValue::from_str(&format!("could not partially sign message: {}", err)))
 }
 
@@ -160,7 +153,7 @@ pub fn partial_verify(polynomial_buf: &[u8], blinded_message: &[u8], sig: &[u8])
         .unmarshal(&polynomial_buf)
         .map_err(|err| JsValue::from_str(&format!("could not unmarshal polynomial {}", err)))?;
 
-    BlindThresholdSigs::partial_verify(&polynomial, blinded_message, sig)
+    SigScheme::partial_verify(&polynomial, blinded_message, sig)
         .map_err(|err| JsValue::from_str(&format!("could not partially verify message: {}", err)))
 }
 
@@ -195,7 +188,7 @@ pub fn combine(threshold: usize, signatures: Vec<u8>) -> Result<Vec<u8>> {
         .map(|chunk| chunk.to_vec())
         .collect::<Vec<Vec<u8>>>();
 
-    BlindThresholdSigs::aggregate(threshold, &sigs)
+    SigScheme::aggregate(threshold, &sigs)
         .map_err(|err| JsValue::from_str(&format!("could not aggregate sigs: {}", err,)))
 }
 
@@ -288,7 +281,7 @@ impl Keypair {
 #[wasm_bindgen]
 pub fn keygen(seed: Vec<u8>) -> Keypair {
     let mut rng = get_rng(&seed);
-    let (private, public) = BlindThresholdSigs::keypair(&mut rng);
+    let (private, public) = SigScheme::keypair(&mut rng);
     Keypair { private, public }
 }
 

--- a/crates/threshold-bls/Cargo.toml
+++ b/crates/threshold-bls/Cargo.toml
@@ -26,6 +26,7 @@ groupy = {version = "0.3.0", optional = true }
 # bls12_377
 algebra = { git = "https://github.com/scipr-lab/zexe", features = ["bls12_377", "edwards_sw6"], optional = true }
 bls-crypto = { git = "https://github.com/celo-org/bls-zexe", optional = true }
+thiserror = "1.0.15"
 
 [features]
 default = ["bls12_381", "bls12_377"]

--- a/crates/threshold-bls/src/curve/bls12381.rs
+++ b/crates/threshold-bls/src/curve/bls12381.rs
@@ -236,6 +236,7 @@ impl C for TrialCurve {
     type Point = G1;
 }
 
+#[derive(Clone, Debug)]
 pub struct PairingCurve;
 
 impl PC for PairingCurve {

--- a/crates/threshold-bls/src/curve/mod.rs
+++ b/crates/threshold-bls/src/curve/mod.rs
@@ -1,25 +1,19 @@
-use std::error::Error;
-use std::fmt;
-
 #[cfg(feature = "bls12_381")]
 pub mod bls12381;
 
 #[cfg(feature = "bls12_377")]
 pub mod zexe;
 
-#[derive(Debug)]
-pub struct InvalidLength(usize, usize);
+use thiserror::Error;
 
-impl fmt::Display for InvalidLength {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "decoding: invalid length {}/{}", self.0, self.1)
-    }
-}
+/// Error which unifies all curve specific errors from different libraries
+#[derive(Debug, Error)]
+pub enum CurveError {
+    #[cfg(feature = "bls12_377")]
+    #[error("Zexe Error: {0}")]
+    BLS12_377(zexe::ZexeError),
 
-impl Error for InvalidLength {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        // Generic error, underlying cause isn't tracked.
-        // TODO
-        None
-    }
+    #[cfg(feature = "bls12_381")]
+    #[error("Bellman Error: {0}")]
+    BLS12_381(bls12381::BellmanError),
 }

--- a/crates/threshold-bls/src/curve/zexe.rs
+++ b/crates/threshold-bls/src/curve/zexe.rs
@@ -291,6 +291,7 @@ impl Curve for G2Curve {
     type Point = G2;
 }
 
+#[derive(Clone, Debug)]
 pub struct PairingCurve {}
 
 impl PC for PairingCurve {

--- a/crates/threshold-bls/src/group.rs
+++ b/crates/threshold-bls/src/group.rs
@@ -2,14 +2,14 @@
 
 use rand_core::RngCore;
 use serde::{de::DeserializeOwned, Serialize};
-use std::fmt;
+use std::fmt::{Debug, Display};
 use std::marker::PhantomData;
 
 /// Element represents an element of a group with the additive notation
 /// which is also equipped with a multiplication transformation.
 /// Two implementations are for Scalar which forms a ring so RHS is the same
 /// and Point which can be multiplied by a scalar of its prime field.
-pub trait Element<RHS = Self>: Clone + fmt::Display + fmt::Debug + Eq {
+pub trait Element<RHS = Self>: Clone + Display + Debug + Eq {
     /// new MUST return the zero element of the group.
     fn new() -> Self;
     fn one() -> Self;
@@ -33,7 +33,7 @@ pub trait Scalar: Element + Encodable {
 
 /// Basic point functionality that can be multiplied by a scalar
 pub trait Point<A: Scalar>: Element<A> + Encodable {
-    type Error;
+    type Error: Debug;
 
     fn map(&mut self, data: &[u8]) -> Result<(), <Self as Point<A>>::Error>;
 }
@@ -42,7 +42,7 @@ pub trait Point<A: Scalar>: Element<A> + Encodable {
 
 /// A group holds functionalities to create scalar and points related; it is
 /// similar to the Engine definition, just much more simpler.
-pub trait Curve: Clone + std::fmt::Debug {
+pub trait Curve: Clone + Debug {
     type Scalar: Scalar;
     type Point: Point<Self::Scalar>;
 
@@ -57,7 +57,7 @@ pub trait Curve: Clone + std::fmt::Debug {
     }
 }
 
-pub trait PairingCurve {
+pub trait PairingCurve: Debug {
     type Scalar: Scalar;
     type G1: Point<Self::Scalar> + Encodable;
     type G2: Point<Self::Scalar> + Encodable;

--- a/crates/threshold-bls/src/group.rs
+++ b/crates/threshold-bls/src/group.rs
@@ -1,6 +1,7 @@
+//! Traits for operating on Groups and Elliptic Curves.
+
 use rand_core::RngCore;
 use serde::{de::DeserializeOwned, Serialize};
-use std::error::Error;
 use std::fmt;
 use std::marker::PhantomData;
 
@@ -32,7 +33,9 @@ pub trait Scalar: Element + Encodable {
 
 /// Basic point functionality that can be multiplied by a scalar
 pub trait Point<A: Scalar>: Element<A> + Encodable {
-    fn map(&mut self, data: &[u8]) -> Result<(), Box<dyn Error>>;
+    type Error;
+
+    fn map(&mut self, data: &[u8]) -> Result<(), <Self as Point<A>>::Error>;
 }
 
 //type PPoint = Point<A: Scalar>;
@@ -82,11 +85,9 @@ pub type G1Curve<C> = CurveFrom<<C as PairingCurve>::Scalar, <C as PairingCurve>
 pub type G2Curve<C> = CurveFrom<<C as PairingCurve>::Scalar, <C as PairingCurve>::G2>;
 
 pub trait Encodable: Serialize + DeserializeOwned {
+    type Error: std::error::Error;
+
     fn marshal_len() -> usize;
     fn marshal(&self) -> Vec<u8>;
-    fn unmarshal(&mut self, data: &[u8]) -> Result<(), Box<dyn Error>>;
-}
-
-pub enum DecodingError {
-    InvalidPoint,
+    fn unmarshal(&mut self, data: &[u8]) -> Result<(), Self::Error>;
 }

--- a/crates/threshold-bls/src/lib.rs
+++ b/crates/threshold-bls/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, convert::TryInto};
+use std::{convert::TryInto, fmt::Debug};
 
 pub mod curve;
 pub mod ecies;

--- a/crates/threshold-bls/src/sig/blind.rs
+++ b/crates/threshold-bls/src/sig/blind.rs
@@ -73,9 +73,10 @@ impl<I: SignatureScheme> Blinder for I {
         sig.unmarshal(sigbuff)
             .map_err(BlinderError::EncodableError)?;
 
-        let ri = t.0.inverse().ok_or(BlinderError::InvalidToken)?;
         // r^-1 * ( r * H(m)^x) = H(m)^x
+        let ri = t.0.inverse().ok_or(BlinderError::InvalidToken)?;
         sig.mul(&ri);
+
         Ok(sig.marshal())
     }
 }

--- a/crates/threshold-bls/src/sig/blind.rs
+++ b/crates/threshold-bls/src/sig/blind.rs
@@ -1,11 +1,20 @@
 use crate::group::{Element, Encodable, Point, Scalar};
-use crate::sig::bls::{self, BLSError};
-use crate::sig::{BlindScheme, Blinder, Scheme as SScheme, SignatureScheme};
+use crate::sig::{BlindScheme, Blinder, SignatureScheme};
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
-use std::error::Error;
-use std::fmt;
-use std::marker::PhantomData;
+use thiserror::Error;
+
+/// BlindError are a type of errors that blind signature scheme can return.
+#[derive(Debug, Error)]
+pub enum BlinderError<E: Encodable + std::fmt::Debug> {
+    /// InvalidToken is thrown out when the token used to unblind can not be
+    /// inversed. This error should not happen if you use the Token that was
+    /// returned by the blind operation.
+    #[error("invalid token")]
+    InvalidToken,
+    #[error("could not deserialize scalar: {0}")]
+    EncodableError(E::Error),
+}
 
 /// Blinding a message before requesting a signature requires the usage of a
 /// private blinding factor that is called a Token. To unblind the signature
@@ -21,61 +30,29 @@ impl<S: Scalar> Token<S> {
     }
 }
 
-impl<S> Encodable for Token<S>
-where
-    S: Scalar,
-{
+impl<S: Scalar> Encodable for Token<S> {
+    type Error = <S as Encodable>::Error;
+
     fn marshal_len() -> usize {
         <S as Encodable>::marshal_len()
     }
     fn marshal(&self) -> Vec<u8> {
         self.0.marshal()
     }
-    fn unmarshal(&mut self, data: &[u8]) -> Result<(), Box<dyn Error>> {
+    fn unmarshal(&mut self, data: &[u8]) -> Result<(), Self::Error> {
         self.0.unmarshal(data)
     }
 }
-/// Scheme implements the signature scheme interface as well as the blinder
-/// interface to provide a blind signature scheme. It follows the protocol described
+
+// We implement Blinder for anything that implements Signature scheme, so we also
+// enable the BlindScheme for all these, for convenience
+impl<I> BlindScheme for I where I: SignatureScheme {}
+
+/// The blinder follows the protocol described
 /// in this [paper](https://eprint.iacr.org/2018/733.pdf).
-pub struct Scheme<I: SignatureScheme> {
-    i: PhantomData<I>,
-}
-
-impl<I> SScheme for Scheme<I>
-where
-    I: SignatureScheme,
-{
-    type Private = I::Private;
-    type Public = I::Public;
-    type Signature = I::Signature;
-}
-
-// XXX Why can't I implement just for any T<I> ?
-impl<I> SignatureScheme for Scheme<I>
-where
-    I: SignatureScheme,
-{
-    fn sign(private: &Self::Private, blinded: &[u8]) -> Result<Vec<u8>, Box<dyn Error>> {
-        let mut hm = I::Signature::new();
-        match hm.unmarshal(blinded) {
-            Ok(()) => {
-                hm.mul(private);
-                Ok(hm.marshal())
-            }
-            Err(e) => Err(e),
-        }
-    }
-    fn verify(public: &Self::Public, msg: &[u8], sig: &[u8]) -> Result<(), Box<dyn Error>> {
-        I::verify(public, msg, sig)
-    }
-}
-
-impl<I> Blinder for Scheme<I>
-where
-    I: SignatureScheme,
-{
+impl<I: SignatureScheme> Blinder for I {
     type Token = Token<I::Private>;
+    type Error = BlinderError<I::Signature>;
 
     fn blind<R: RngCore>(msg: &[u8], rng: &mut R) -> (Self::Token, Vec<u8>) {
         let mut r = I::Private::new();
@@ -85,113 +62,58 @@ where
 
         // r * H(m)
         // XXX result from zexe API but it shouldn't
-        h.map(msg).unwrap();
+        h.map(msg).expect("could not map to the group");
         h.mul(&r);
+
         (Token(r), h.marshal())
     }
 
-    fn unblind(t: &Self::Token, sigbuff: &[u8]) -> Result<Vec<u8>, Box<dyn Error>> {
+    fn unblind(t: &Self::Token, sigbuff: &[u8]) -> Result<Vec<u8>, Self::Error> {
         let mut sig = I::Signature::new();
-        if let Err(_) = sig.unmarshal(sigbuff) {
-            return Err(Box::new(BlindError::SigError(BLSError::InvalidPoint)));
-        }
-        match t.0.inverse() {
-            Some(ri) => {
-                // r^-1 * ( r * H(m)^x) = H(m)^x
-                sig.mul(&ri);
-                Ok(sig.marshal())
-            }
-            None => Err(Box::new(BlindError::InvalidToken)),
-        }
-    }
-}
+        sig.unmarshal(sigbuff)
+            .map_err(BlinderError::EncodableError)?;
 
-impl<I> BlindScheme for Scheme<I> where I: SignatureScheme {}
-
-/// BlindError are a type of errors that blind signature scheme can return.
-#[derive(Debug)]
-pub enum BlindError {
-    /// InvalidToken is thrown out when the token used to unblind can not be
-    /// inversed. This error should not happen if you use the Token that was
-    /// returned by the blind operation.
-    InvalidToken,
-    /// BLS errors are thrown out by the currently implemented scheme since it
-    /// uses BLS verification routines underneath.
-    SigError(BLSError),
-}
-
-/// BG2Scheme is a blind signature scheme implementation that operates with
-/// private/public key pairs over G1 and signatures over G2 using the
-/// parametrized pairing curve.
-pub type BG2Scheme<C> = Scheme<bls::G2Scheme<C>>;
-/// BG1Scheme is a blind signature scheme implementation that operates with
-/// private/public key pairs over G2 and signatures over G1 using the
-/// parametrized pairing curve.
-pub type BG1Scheme<C> = Scheme<bls::G1Scheme<C>>;
-
-impl fmt::Display for BlindError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            BlindError::InvalidToken => write!(f, "invalid token"),
-            BlindError::SigError(e) => write!(f, "BLS error: {}", e),
-        }
-    }
-}
-
-impl Error for BlindError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            BlindError::InvalidToken => None,
-            BlindError::SigError(e) => Some(e),
-        }
+        let ri = t.0.inverse().ok_or(BlinderError::InvalidToken)?;
+        // r^-1 * ( r * H(m)^x) = H(m)^x
+        sig.mul(&ri);
+        Ok(sig.marshal())
     }
 }
 
 #[cfg(test)]
+#[cfg(feature = "bls12_381")]
 mod tests {
     use super::*;
-    #[cfg(feature = "bls12_381")]
     use crate::curve::bls12381::PairingCurve as PCurve;
+    use crate::sig::bls::{G1Scheme, G2Scheme};
     use rand::thread_rng;
 
-    fn pair<B: SignatureScheme>() -> (B::Private, B::Public) {
-        let mut private = B::Private::new();
-        let mut public = B::Public::one();
-        private.pick(&mut thread_rng());
-        public.mul(&private);
-        (private, public)
-    }
-
-    #[cfg(feature = "bls12_381")]
     #[test]
     fn blind_g1() {
-        blind_test::<BG1Scheme<PCurve>>();
+        blind_test::<G1Scheme<PCurve>>();
     }
 
     #[cfg(feature = "bls12_381")]
     #[test]
     fn blind_g2() {
-        blind_test::<BG2Scheme<PCurve>>();
+        blind_test::<G2Scheme<PCurve>>();
     }
 
     fn blind_test<B>()
     where
         B: BlindScheme,
     {
-        let (private, public) = pair::<B>();
+        let (private, public) = B::keypair(&mut thread_rng());
         let msg = vec![1, 9, 6, 9];
+
         let (token, blinded) = B::blind(&msg, &mut thread_rng());
         let blinded_sig = B::sign(&private, &blinded).unwrap();
         let clear_sig = B::unblind(&token, &blinded_sig).expect("unblind should go well");
+
         let mut msg_point = B::Signature::new();
         msg_point.map(&msg).unwrap();
         let msg_point_bytes = msg_point.marshal();
-        match B::verify(&public, &msg_point_bytes, &clear_sig) {
-            Ok(()) => {}
-            Err(e) => {
-                println!("{:?}", e);
-                assert!(false);
-            }
-        }
+
+        B::verify(&public, &msg_point_bytes, &clear_sig).unwrap();
     }
 }

--- a/crates/threshold-bls/src/sig/bls.rs
+++ b/crates/threshold-bls/src/sig/bls.rs
@@ -1,8 +1,19 @@
 use crate::group::{Element, Encodable, PairingCurve};
 use crate::sig::{Scheme, SignatureScheme};
-use std::error::Error;
-use std::fmt;
-use std::marker::PhantomData;
+use std::{fmt::Debug, marker::PhantomData};
+use thiserror::Error;
+
+/// BLSError are thrown out when using the BLS signature scheme.
+#[derive(Debug, Error)]
+pub enum BLSError<E: Encodable + Debug> {
+    /// InvalidSig is raised when the validation routine of the BLS algorithm
+    /// does not finish successfully,i.e. it is an invalid signature.
+    #[error("invalid signature")]
+    InvalidSig,
+
+    #[error("could not decode data: {0}")]
+    EncodableError(E::Error),
+}
 
 // private module workaround to avoid leaking a private
 // trait into a public trait
@@ -10,33 +21,23 @@ use std::marker::PhantomData;
 // XXX another way to pull it off without this hack?
 mod common {
     use super::*;
-    // BLSScheme is an internal trait that encompasses the common work between a
-    // BLS signature over G1 or G2.
+
+    /// BLSScheme is an internal trait that encompasses the common work between a
+    /// BLS signature over G1 or G2.
     pub trait BLSScheme: Scheme {
-        fn internal_sign(private: &Self::Private, msg: &[u8]) -> Result<Vec<u8>, Box<dyn Error>> {
-            // sig = H(m)^x
+        /// Returns sig = msg^{private}. The message MUST be hashed before this call.
+        fn internal_sign(
+            private: &Self::Private,
+            msg: &[u8],
+        ) -> Result<Vec<u8>, BLSError<Self::Signature>> {
             let mut h = Self::Signature::new();
-            h.unmarshal(msg)?;
+            h.unmarshal(msg).map_err(BLSError::EncodableError)?;
             h.mul(private);
 
             Ok(h.marshal())
         }
 
-        fn internal_verify(
-            msg: &[u8],
-            sig: &[u8],
-        ) -> Result<(Self::Signature, Self::Signature), Box<dyn Error>> {
-            let mut sigp = Self::Signature::new();
-            if let Err(_) = sigp.unmarshal(sig) {
-                return Err(Box::new(BLSError::InvalidPoint));
-            }
-
-            // m
-            let mut h = Self::Signature::new();
-            h.unmarshal(msg)?;
-            return Ok((sigp, h));
-        }
-
+        /// Performs the final exponentiation for the BLS sig scheme
         fn final_exp(p: &Self::Public, sig: &Self::Signature, hm: &Self::Signature) -> bool;
     }
 
@@ -44,19 +45,34 @@ mod common {
     where
         T: BLSScheme,
     {
-        fn sign(private: &Self::Private, msg: &[u8]) -> Result<Vec<u8>, Box<dyn Error>> {
+        type Error = BLSError<T::Signature>;
+
+        fn sign(private: &Self::Private, msg: &[u8]) -> Result<Vec<u8>, Self::Error> {
             T::internal_sign(private, msg)
         }
 
-        fn verify(public: &Self::Public, msg: &[u8], sig: &[u8]) -> Result<(), Box<dyn Error>> {
-            let (sig, hm) = T::internal_verify(msg, sig)?;
-            if T::final_exp(public, &sig, &hm) {
-                Ok(())
-            } else {
-                Err(Box::new(BLSError::InvalidSig))
+        /// Verifies the signature by the provided public key **on the message's hash**.
+        fn verify(
+            public: &Self::Public,
+            msg_bytes: &[u8],
+            sig_bytes: &[u8],
+        ) -> Result<(), Self::Error> {
+            let mut sig = Self::Signature::new();
+            sig.unmarshal(sig_bytes).map_err(BLSError::EncodableError)?;
+
+            let mut hm = Self::Signature::new();
+            hm.unmarshal(msg_bytes).map_err(BLSError::EncodableError)?;
+
+            let success = T::final_exp(public, &sig, &hm);
+            if !success {
+                return Err(BLSError::InvalidSig);
             }
+
+            Ok(())
         }
+
     }
+
 }
 
 /// G1Scheme implements the BLS signature scheme with G1 as private / public
@@ -112,35 +128,6 @@ where
         let left = C::pair(&sig, &Self::Public::one());
         let right = C::pair(&hm, p);
         left == right
-    }
-}
-
-/// BLSError are thrown out when using the BLS signature scheme.
-#[derive(Debug)]
-pub enum BLSError {
-    /// InvalidPoint is raised when signature given to verification is not a
-    /// valid point on the curve.
-    InvalidPoint,
-    /// InvalidSig is raised when the validation routine of the BLS algorithm
-    /// does not finish successfully,i.e. it is an invalid signature.
-    InvalidSig,
-}
-
-impl fmt::Display for BLSError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use BLSError::*;
-        match self {
-            InvalidPoint => write!(f, "invalid point signature"),
-            InvalidSig => write!(f, "invalid signature"),
-        }
-    }
-}
-
-impl Error for BLSError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        // Generic error, underlying cause isn't tracked.
-        // TODO
-        None
     }
 }
 

--- a/crates/threshold-bls/src/sig/bls.rs
+++ b/crates/threshold-bls/src/sig/bls.rs
@@ -70,13 +70,12 @@ mod common {
 
             Ok(())
         }
-
     }
-
 }
 
 /// G1Scheme implements the BLS signature scheme with G1 as private / public
 /// keys and G2 as signature elements over the given pairing curve.
+#[derive(Clone, Debug)]
 pub struct G1Scheme<C: PairingCurve> {
     m: PhantomData<C>,
 }
@@ -105,6 +104,7 @@ where
 
 /// G2Scheme implements the BLS signature scheme with G2 as private / public
 /// keys and G1 as signature elements over the given pairing curve.
+#[derive(Clone, Debug)]
 pub struct G2Scheme<C: PairingCurve> {
     m: PhantomData<C>,
 }

--- a/crates/threshold-bls/src/sig/sig.rs
+++ b/crates/threshold-bls/src/sig/sig.rs
@@ -69,8 +69,10 @@ pub trait SignatureScheme: Scheme {
 /// threshold scheme.
 pub trait Blinder {
     type Token: Encodable;
+    type Error: Error;
+
     fn blind<R: RngCore>(msg: &[u8], rng: &mut R) -> (Self::Token, Vec<u8>);
-    fn unblind(t: &Self::Token, sig: &[u8]) -> Result<Vec<u8>, Box<dyn Error>>;
+    fn unblind(t: &Self::Token, sig: &[u8]) -> Result<Vec<u8>, Self::Error>;
 }
 
 /// BlindScheme is a signature scheme where the message can be blinded before

--- a/crates/threshold-bls/src/sig/sig.rs
+++ b/crates/threshold-bls/src/sig/sig.rs
@@ -89,32 +89,28 @@ pub type Partial = Vec<u8>;
 /// signature" to then produce a regular signature.
 /// The `dkg` module allows participants to create a distributed private/public key
 /// that can be used with implementations `ThresholdScheme`.
-pub trait ThresholdScheme: SignatureScheme {
+pub trait ThresholdScheme: Scheme {
     type Error: Error;
 
-    fn partial_sign(
-        private: &Share<Self::Private>,
-        msg: &[u8],
-    ) -> Result<Partial, <Self as ThresholdScheme>::Error>;
+    fn partial_sign(private: &Share<Self::Private>, msg: &[u8]) -> Result<Partial, Self::Error>;
     fn partial_verify(
         public: &Poly<Self::Private, Self::Public>,
         msg: &[u8],
         partial: &[u8],
-    ) -> Result<(), <Self as ThresholdScheme>::Error>;
+    ) -> Result<(), Self::Error>;
 
     /// Aggregates all partials signature together. Note that this method does
     /// not verify if the partial signatures are correct or not; it only
     /// aggregates them.
-    fn aggregate(
-        threshold: usize,
-        partials: &[Partial],
-    ) -> Result<Vec<u8>, <Self as ThresholdScheme>::Error>;
+    fn aggregate(threshold: usize, partials: &[Partial]) -> Result<Vec<u8>, Self::Error>;
+
+    fn verify(public: &Self::Public, msg: &[u8], sig: &[u8]) -> Result<(), Self::Error>;
 }
 
 /// BlindThreshold is ThresholdScheme that allows to verifiy a partially blinded
 /// signature as well blinded message, to aggregate them into one blinded signature
 /// such that it can be unblinded after and verified as a regular signature.
-pub trait BlindThreshold: ThresholdScheme + BlindScheme {
+pub trait BlindThresholdScheme: ThresholdScheme + Blinder {
     type Error: Error;
 
     /// unblind_partial takes a blinded partial signatures and removes the blind
@@ -122,5 +118,5 @@ pub trait BlindThreshold: ThresholdScheme + BlindScheme {
     fn unblind_partial(
         t: &Self::Token,
         partial: &Partial,
-    ) -> Result<Partial, <Self as BlindThreshold>::Error>;
+    ) -> Result<Partial, <Self as BlindThresholdScheme>::Error>;
 }

--- a/crates/threshold-bls/src/sig/sig.rs
+++ b/crates/threshold-bls/src/sig/sig.rs
@@ -58,8 +58,10 @@ pub trait Scheme {
 /// ```
 /// Note signature scheme handles the format of the signature itself.
 pub trait SignatureScheme: Scheme {
-    fn sign(private: &Self::Private, msg: &[u8]) -> Result<Vec<u8>, Box<dyn Error>>;
-    fn verify(public: &Self::Public, msg: &[u8], sig: &[u8]) -> Result<(), Box<dyn Error>>;
+    type Error;
+
+    fn sign(private: &Self::Private, msg: &[u8]) -> Result<Vec<u8>, Self::Error>;
+    fn verify(public: &Self::Public, msg: &[u8], sig: &[u8]) -> Result<(), Self::Error>;
 }
 
 /// Blinder holds the functionality of blinding and unblinding a message. It is

--- a/crates/threshold-bls/src/sig/sig.rs
+++ b/crates/threshold-bls/src/sig/sig.rs
@@ -2,7 +2,7 @@ use crate::group::{Element, Encodable, Point, Scalar};
 use crate::poly::Poly;
 use crate::Share;
 use rand_core::RngCore;
-use std::error::Error;
+use std::{error::Error, fmt::Debug};
 
 /// The `Scheme` trait contains the basic information of the groups over
 /// which the signing operations takes places and a way to create a valid key
@@ -10,7 +10,7 @@ use std::error::Error;
 ///
 /// The Scheme trait is necessary to implement for "simple" signature scheme as
 /// well for threshold based signature scheme.
-pub trait Scheme {
+pub trait Scheme: Debug {
     /// `Private` represents the field over which private keys are represented.
     type Private: Scalar;
     /// `Public` represents the group over which the public keys are
@@ -58,7 +58,7 @@ pub trait Scheme {
 /// ```
 /// Note signature scheme handles the format of the signature itself.
 pub trait SignatureScheme: Scheme {
-    type Error;
+    type Error: Error;
 
     fn sign(private: &Self::Private, msg: &[u8]) -> Result<Vec<u8>, Self::Error>;
     fn verify(public: &Self::Public, msg: &[u8], sig: &[u8]) -> Result<(), Self::Error>;
@@ -87,18 +87,26 @@ pub type Partial = Vec<u8>;
 /// signature" to then produce a regular signature.
 /// The `dkg` module allows participants to create a distributed private/public key
 /// that can be used with implementations `ThresholdScheme`.
-pub trait ThresholdScheme: Scheme {
-    fn partial_sign(private: &Share<Self::Private>, msg: &[u8]) -> Result<Partial, Box<dyn Error>>;
+pub trait ThresholdScheme: SignatureScheme {
+    type Error: Error;
+
+    fn partial_sign(
+        private: &Share<Self::Private>,
+        msg: &[u8],
+    ) -> Result<Partial, <Self as ThresholdScheme>::Error>;
     fn partial_verify(
         public: &Poly<Self::Private, Self::Public>,
         msg: &[u8],
         partial: &[u8],
-    ) -> Result<(), Box<dyn Error>>;
+    ) -> Result<(), <Self as ThresholdScheme>::Error>;
+
     /// Aggregates all partials signature together. Note that this method does
     /// not verify if the partial signatures are correct or not; it only
     /// aggregates them.
-    fn aggregate(threshold: usize, partials: &[Partial]) -> Result<Vec<u8>, Box<dyn Error>>;
-    fn verify(public: &Self::Public, msg: &[u8], sig: &[u8]) -> Result<(), Box<dyn Error>>;
+    fn aggregate(
+        threshold: usize,
+        partials: &[Partial],
+    ) -> Result<Vec<u8>, <Self as ThresholdScheme>::Error>;
 }
 
 /// BlindThreshold is ThresholdScheme that allows to verifiy a partial blinded

--- a/crates/threshold-bls/src/sig/sig.rs
+++ b/crates/threshold-bls/src/sig/sig.rs
@@ -111,11 +111,16 @@ pub trait ThresholdScheme: SignatureScheme {
     ) -> Result<Vec<u8>, <Self as ThresholdScheme>::Error>;
 }
 
-/// BlindThreshold is ThresholdScheme that allows to verifiy a partial blinded
+/// BlindThreshold is ThresholdScheme that allows to verifiy a partially blinded
 /// signature as well blinded message, to aggregate them into one blinded signature
 /// such that it can be unblinded after and verified as a regular signature.
-pub trait BlindThreshold: ThresholdScheme + Blinder {
+pub trait BlindThreshold: ThresholdScheme + BlindScheme {
+    type Error: Error;
+
     /// unblind_partial takes a blinded partial signatures and removes the blind
     /// component.
-    fn unblind_partial(t: &Self::Token, partial: &Partial) -> Result<Partial, Box<dyn Error>>;
+    fn unblind_partial(
+        t: &Self::Token,
+        partial: &Partial,
+    ) -> Result<Partial, <Self as BlindThreshold>::Error>;
 }

--- a/crates/threshold-bls/src/sig/tbls.rs
+++ b/crates/threshold-bls/src/sig/tbls.rs
@@ -40,6 +40,8 @@ pub trait Serializer {
     }
 }
 
+impl<I: SignatureScheme> Serializer for I {}
+
 impl<I: SignatureScheme> ThresholdScheme for I {
     type Error = ThresholdError<I>;
 

--- a/crates/threshold-bls/src/sig/tbls.rs
+++ b/crates/threshold-bls/src/sig/tbls.rs
@@ -100,6 +100,10 @@ impl<I: SignatureScheme> ThresholdScheme for I {
                 .map_err(ThresholdError::PolyError)?;
         Ok(recovered_sig.marshal())
     }
+
+    fn verify(public: &Self::Public, msg: &[u8], sig: &[u8]) -> Result<(), Self::Error> {
+        <Self as SignatureScheme>::verify(public, msg, sig).map_err(ThresholdError::SignatureError)
+    }
 }
 
 fn inject_index(index: Index, sig: &[u8]) -> Vec<u8> {
@@ -184,6 +188,7 @@ mod tests {
                 .any(|p| T::partial_verify(&public, &msg_point_bytes, &p).is_err())
         );
         let final_sig = T::aggregate(threshold, &partials).unwrap();
+
         T::verify(&public.free_coeff(), &msg_point_bytes, &final_sig).unwrap();
     }
 

--- a/crates/threshold-bls/src/sig/tbls.rs
+++ b/crates/threshold-bls/src/sig/tbls.rs
@@ -35,7 +35,7 @@ pub trait Serializer {
         extract_index(partial)
     }
 
-    fn inject(idx: Index, partial: &mut Partial) -> Vec<u8> {
+    fn inject(idx: Index, partial: &[u8]) -> Vec<u8> {
         inject_index(idx, partial)
     }
 }
@@ -102,12 +102,10 @@ impl<I: SignatureScheme> ThresholdScheme for I {
     }
 }
 
-fn inject_index(index: Index, sig: &mut Vec<u8>) -> Vec<u8> {
-    let mut idx_slice = index.to_le_bytes().to_vec();
-    let mut full_vector = Vec::with_capacity(idx_slice.len() + sig.len());
-    full_vector.append(&mut idx_slice);
-    full_vector.append(sig);
-    full_vector
+fn inject_index(index: Index, sig: &[u8]) -> Vec<u8> {
+    let mut res = index.to_le_bytes().to_vec();
+    res.extend_from_slice(sig);
+    res
 }
 
 fn extract_index(sig: &[u8]) -> Result<(Index, Vec<u8>), IndexSerializerError> {
@@ -159,10 +157,10 @@ mod tests {
 
     #[test]
     fn inject() {
-        let mut sig: Vec<u8> = (0..48).collect();
+        let sig: Vec<u8> = (0..48).collect();
         let siglen = sig.len();
         let c = sig.clone();
-        let extended = inject_index(4 as Index, &mut sig);
+        let extended = inject_index(4 as Index, &sig);
         let size_idx = std::mem::size_of::<Index>();
         assert_eq!(extended.len(), siglen + size_idx);
         assert_eq!(&extended[size_idx..], c.as_slice());

--- a/crates/threshold-bls/src/sig/tbls.rs
+++ b/crates/threshold-bls/src/sig/tbls.rs
@@ -1,43 +1,53 @@
+//! Implements Threshold Signatures for all Signature Scheme implementers
 use crate::group::{Element, Encodable};
-use crate::poly::{Eval, Poly};
-use crate::sig::bls;
-use crate::sig::{Partial, Scheme as SScheme, SignatureScheme, ThresholdScheme};
+use crate::poly::{Eval, Poly, PolyError};
+use crate::sig::{Partial, SignatureScheme, ThresholdScheme};
 use crate::{Index, Share};
-use std::convert::TryInto;
-use std::error::Error;
-use std::fmt;
-use std::marker::PhantomData;
+use std::{convert::TryInto, fmt::Debug};
+use thiserror::Error;
 
+#[derive(Debug, Error)]
+pub enum IndexSerializerError {
+    #[error("signature did not contain an index, need at least {1} bytes, got {0}")]
+    InvalidLength(usize, usize),
+    #[error("could not deserialize index: {0}")]
+    IndexError(#[from] std::array::TryFromSliceError),
+}
+
+#[derive(Debug, Error)]
+pub enum ThresholdError<I: SignatureScheme> {
+    #[error("could not recover public key: {0}")]
+    PolyError(PolyError<I::Signature>),
+
+    #[error(transparent)]
+    IndexError(#[from] IndexSerializerError),
+
+    #[error("signing error {0}")]
+    SignatureError(I::Error),
+
+    #[error("not enough partial signatures: {0}/{1}")]
+    NotEnoughPartialSignatures(usize, usize),
+}
+
+/// Helper trait for serializing/deserializing indexes in a signature
 pub trait Serializer {
-    fn extract(partial: &[u8]) -> Result<(Index, Partial), TBLSError> {
+    fn extract(partial: &[u8]) -> Result<(Index, Partial), IndexSerializerError> {
         extract_index(partial)
     }
+
     fn inject(idx: Index, partial: &mut Partial) -> Vec<u8> {
         inject_index(idx, partial)
     }
 }
 
-impl<I> Serializer for TScheme<I> where I: SignatureScheme {}
+impl<I: SignatureScheme> ThresholdScheme for I {
+    type Error = ThresholdError<I>;
 
-pub struct TScheme<I: SignatureScheme> {
-    i: PhantomData<I>,
-}
-
-impl<I> SScheme for TScheme<I>
-where
-    I: SignatureScheme,
-{
-    type Private = I::Private;
-    type Public = I::Public;
-    type Signature = I::Signature;
-}
-
-impl<I> ThresholdScheme for TScheme<I>
-where
-    I: SignatureScheme,
-{
-    fn partial_sign(private: &Share<Self::Private>, msg: &[u8]) -> Result<Vec<u8>, Box<dyn Error>> {
-        let mut sig = I::sign(&private.private, msg)?;
+    fn partial_sign(
+        private: &Share<Self::Private>,
+        msg: &[u8],
+    ) -> Result<Vec<u8>, <Self as ThresholdScheme>::Error> {
+        let mut sig = Self::sign(&private.private, msg).map_err(ThresholdError::SignatureError)?;
         let ret = inject_index(private.index, &mut sig);
         Ok(ret)
     }
@@ -46,20 +56,23 @@ where
         public: &Poly<Self::Private, Self::Public>,
         msg: &[u8],
         partial: &[u8],
-    ) -> Result<(), Box<dyn Error>> {
-        match extract_index(partial) {
-            Ok((idx, bls_sig)) => {
-                let public_i = public.eval(idx);
-                I::verify(&public_i.value, msg, &bls_sig)
-            }
-            Err(e) => Err(Box::new(e)),
-        }
+    ) -> Result<(), <Self as ThresholdScheme>::Error> {
+        let (idx, bls_sig) = extract_index(partial)?;
+        let public_i = public.eval(idx);
+        Self::verify(&public_i.value, msg, &bls_sig).map_err(ThresholdError::SignatureError)
     }
 
-    fn aggregate(threshold: usize, partials: &[Partial]) -> Result<Vec<u8>, Box<dyn Error>> {
+    fn aggregate(
+        threshold: usize,
+        partials: &[Partial],
+    ) -> Result<Vec<u8>, <Self as ThresholdScheme>::Error> {
         if threshold > partials.len() {
-            return Err(Box::new(TBLSError::NotEnoughPartialSignatures));
+            return Err(ThresholdError::NotEnoughPartialSignatures(
+                partials.len(),
+                threshold,
+            ));
         }
+
         let valid_partials: Vec<Eval<Self::Signature>> = partials
             .iter()
             .map(|s| extract_index(s))
@@ -79,40 +92,11 @@ where
             })
             .filter_map(Result::ok)
             .collect();
+
         let recovered_sig =
-            Poly::<Self::Private, Self::Signature>::recover(threshold, valid_partials)?;
+            Poly::<Self::Private, Self::Signature>::recover(threshold, valid_partials)
+                .map_err(ThresholdError::PolyError)?;
         Ok(recovered_sig.marshal())
-    }
-
-    fn verify(public: &Self::Public, msg: &[u8], sig: &[u8]) -> Result<(), Box<dyn Error>> {
-        I::verify(public, msg, sig)
-    }
-}
-
-#[derive(Debug)]
-pub enum TBLSError {
-    BLSError,
-    InvalidLength,
-    NotEnoughPartialSignatures,
-}
-
-impl fmt::Display for TBLSError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use TBLSError::*;
-        match self {
-            InvalidLength => write!(f, "invalid length of signature"),
-            NotEnoughPartialSignatures => write!(f, "not enough partial signatures"),
-            BLSError => write!(f, "{}", self),
-        }
-    }
-}
-
-// This is important for other errors to wrap this one.
-impl Error for TBLSError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        // Generic error, underlying cause isn't tracked.
-        // TODO
-        None
     }
 }
 
@@ -124,18 +108,16 @@ fn inject_index(index: Index, sig: &mut Vec<u8>) -> Vec<u8> {
     full_vector
 }
 
-fn extract_index(sig: &[u8]) -> Result<(Index, Vec<u8>), TBLSError> {
+fn extract_index(sig: &[u8]) -> Result<(Index, Vec<u8>), IndexSerializerError> {
     let size_idx = std::mem::size_of::<Index>();
     if sig.len() < size_idx {
-        return Err(TBLSError::InvalidLength);
+        return Err(IndexSerializerError::InvalidLength(sig.len(), size_idx));
     }
+
     let (int_bytes, rest) = sig.split_at(size_idx);
-    let index = Index::from_le_bytes(int_bytes.try_into().unwrap());
+    let index = Index::from_le_bytes(int_bytes.try_into()?);
     Ok((index, rest.to_vec()))
 }
-
-pub type TG1Scheme<C> = TScheme<bls::G1Scheme<C>>;
-pub type TG2Scheme<C> = TScheme<bls::G2Scheme<C>>;
 
 #[cfg(feature = "bls12_381")]
 #[cfg(test)]
@@ -143,13 +125,17 @@ mod tests {
     use super::*;
     use crate::curve::bls12381::PairingCurve as PCurve;
     use crate::group::{Encodable, Point};
+    use crate::sig::{
+        bls::{G1Scheme, G2Scheme},
+        Scheme,
+    };
 
     type ShareCreator<T> = fn(
         usize,
         usize,
     ) -> (
-        Vec<Share<<T as SScheme>::Private>>,
-        Poly<<T as SScheme>::Private, <T as SScheme>::Public>,
+        Vec<Share<<T as Scheme>::Private>>,
+        Poly<<T as Scheme>::Private, <T as Scheme>::Public>,
     );
 
     fn shares<T: ThresholdScheme>(
@@ -203,12 +189,13 @@ mod tests {
 
     #[test]
     fn threshold_g1() {
-        test_threshold_scheme::<TG1Scheme<PCurve>>(shares::<TG1Scheme<PCurve>>);
+        type S = G1Scheme<PCurve>;
+        test_threshold_scheme::<S>(shares::<S>);
     }
 
     #[test]
     fn threshold_g2() {
-        test_threshold_scheme::<TG2Scheme<PCurve>>(shares::<TG2Scheme<PCurve>>);
+        type S = G2Scheme<PCurve>;
+        test_threshold_scheme::<S>(shares::<S>);
     }
-    /*}*/
 }


### PR DESCRIPTION
There is no need to implement a separate wrapper struct for each new functionality we'd like to support. This PR makes the Threshold and Blind functionalities act as an Extension trait over `SignatureScheme`.

Also closes #7 