### PR TITLE
feat(bls): add sign without hashing method

### DIFF
--- a/crates/dkg-core/src/node.rs
+++ b/crates/dkg-core/src/node.rs
@@ -180,7 +180,7 @@ mod tests {
         // generates a partial sig with each share from the dkg
         let partial_sigs = outputs
             .iter()
-            .map(|output| S::partial_sign(&output.share, &blinded_msg[..]).unwrap())
+            .map(|output| S::partial_sign_without_hashing(&output.share, &blinded_msg[..]).unwrap())
             .collect::<Vec<_>>();
 
         // aggregates them
@@ -192,10 +192,7 @@ mod tests {
         // get the public key (we have already checked that all outputs' pubkeys are the same)
         let pubkey = outputs[0].public.public_key();
 
-        // verify the threshold signature _against the hash of the message_
-        let mut msg_point = <S as Scheme>::Signature::new();
-        msg_point.map(&msg).unwrap();
-        let msg = msg_point.marshal();
+        // verify the threshold signature
         S::verify(&pubkey, &msg, &unblinded_sig).unwrap();
     }
 

--- a/crates/dkg-core/src/node.rs
+++ b/crates/dkg-core/src/node.rs
@@ -141,10 +141,10 @@ mod tests {
     use threshold_bls::{
         curve::bls12381::{self, PairingCurve as BLS12_381},
         curve::zexe::{self as bls12_377, PairingCurve as BLS12_377},
-        group::{Element, Encodable, Point},
+        group::Point,
         sig::{
             bls::{G1Scheme, G2Scheme},
-            Blinder, Scheme, ThresholdScheme,
+            BlindThresholdScheme, Scheme,
         },
         Index,
     };
@@ -164,8 +164,7 @@ mod tests {
         C: Curve,
         // We need to bind the Curve's Point and Scalars to the Scheme
         S: Scheme<Public = <C as Curve>::Point, Private = <C as Curve>::Scalar>
-            + Blinder
-            + ThresholdScheme,
+            + BlindThresholdScheme,
         <C as Curve>::Point: Point<S::Private>,
         <S as Scheme>::Signature: Point<<C as Curve>::Scalar>,
     {

--- a/crates/threshold-bls-ffi/src/ffi.rs
+++ b/crates/threshold-bls-ffi/src/ffi.rs
@@ -6,7 +6,10 @@ use threshold_bls::{
     curve::zexe::PairingCurve as Bls12_377,
     group::{Element, Encodable},
     poly::Poly,
-    sig::{blind::Token, bls::G2Scheme, Blinder, Scheme, SignatureScheme, ThresholdScheme},
+    sig::{
+        blind::Token, bls::G2Scheme, Blinder, Scheme, SignatureScheme, SignatureSchemeExt,
+        ThresholdScheme, ThresholdSchemeExt,
+    },
     Index, Share,
 };
 

--- a/crates/threshold-bls-ffi/src/ffi.rs
+++ b/crates/threshold-bls-ffi/src/ffi.rs
@@ -4,7 +4,7 @@ use rand_core::{RngCore, SeedableRng};
 
 use threshold_bls::{
     curve::zexe::PairingCurve as Bls12_377,
-    group::{Element, Encodable, Point},
+    group::{Element, Encodable},
     poly::Poly,
     sig::{blind::Token, bls::G2Scheme, Blinder, Scheme, SignatureScheme, ThresholdScheme},
     Index, Share,
@@ -101,16 +101,11 @@ pub extern "C" fn verify(
     signature: *const Buffer,
 ) -> bool {
     let public_key = unsafe { &*public_key };
-
-    // hashes the message
-    let mut msg_hash = Signature::new();
     let message = <&[u8]>::from(unsafe { &*message });
-    msg_hash.map(&message).unwrap();
-    let msg_hash = msg_hash.marshal();
 
     // checks the signature on the message hash
     let signature = <&[u8]>::from(unsafe { &*signature });
-    match <SigScheme as SignatureScheme>::verify(public_key, &msg_hash, signature) {
+    match <SigScheme as SignatureScheme>::verify(public_key, &message, signature) {
         Ok(_) => true,
         Err(_) => false,
     }
@@ -121,10 +116,6 @@ pub extern "C" fn verify(
 ///////////////////////////////////////////////////////////////////////////
 
 /// Signs the message with the provided private key and returns the signature
-///
-/// # Throws
-///
-/// - If signing fails
 #[no_mangle]
 pub extern "C" fn sign(
     private_key: *const PrivateKey,
@@ -135,6 +126,27 @@ pub extern "C" fn sign(
     let message = <&[u8]>::from(unsafe { &*message });
 
     let sig = match SigScheme::sign(&private_key, &message) {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+
+    unsafe { *signature = Buffer::from(&sig[..]) };
+    std::mem::forget(sig);
+
+    true
+}
+
+/// Signs a *blinded* message with the provided private key and returns the signature
+#[no_mangle]
+pub extern "C" fn sign_blinded_message(
+    private_key: *const PrivateKey,
+    message: *const Buffer,
+    signature: *mut Buffer,
+) -> bool {
+    let private_key = unsafe { &*private_key };
+    let message = <&[u8]>::from(unsafe { &*message });
+
+    let sig = match SigScheme::sign_without_hashing(&private_key, &message) {
         Ok(s) => s,
         Err(_) => return false,
     };
@@ -166,6 +178,27 @@ pub extern "C" fn partial_sign(
     true
 }
 
+/// Signs a *blinded* message with the provided *share* of the private key and returns the
+/// *partial blind* signature.
+#[no_mangle]
+pub extern "C" fn partial_sign_blinded_message(
+    share: *const Share<PrivateKey>,
+    blinded_message: *const Buffer,
+    signature: *mut Buffer,
+) -> bool {
+    let share = unsafe { &*share };
+    let message = unsafe { &*blinded_message };
+    let sig = match SigScheme::partial_sign_without_hashing(share, <&[u8]>::from(message)) {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+
+    unsafe { *signature = Buffer::from(&sig[..]) };
+    std::mem::forget(sig);
+
+    true
+}
+
 ///////////////////////////////////////////////////////////////////////////
 // Combiner -> Library
 ///////////////////////////////////////////////////////////////////////////
@@ -185,6 +218,26 @@ pub extern "C" fn partial_verify(
     let sig = <&[u8]>::from(unsafe { &*sig });
 
     match SigScheme::partial_verify(&polynomial, blinded_message, sig) {
+        Ok(_) => true,
+        Err(_) => false,
+    }
+}
+
+/// Verifies a partial *blinded* signature against the public key corresponding to the secret shared
+/// polynomial.
+#[no_mangle]
+pub extern "C" fn partial_verify_blind_signature(
+    // TODO: The polynomial does not have a constant length type. Is it safe to not
+    // pass any length parameter?
+    polynomial: *const Poly<PrivateKey, PublicKey>,
+    blinded_message: *const Buffer,
+    sig: *const Buffer,
+) -> bool {
+    let polynomial = unsafe { &*polynomial };
+    let blinded_message = <&[u8]>::from(unsafe { &*blinded_message });
+    let sig = <&[u8]>::from(unsafe { &*sig });
+
+    match SigScheme::partial_verify_without_hashing(&polynomial, blinded_message, sig) {
         Ok(_) => true,
         Err(_) => false,
     }
@@ -462,34 +515,56 @@ mod tests {
     use std::mem::MaybeUninit;
 
     #[test]
-    fn blinded_threshold_ffi() {
+    fn threshold_verify_ffi() {
+        threshold_verify_ffi_should_blind(true);
+        threshold_verify_ffi_should_blind(false);
+    }
+
+    fn threshold_verify_ffi_should_blind(should_blind: bool) {
         let seed = b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         let msg = vec![1u8, 2, 3, 4, 6];
         let user_seed = &b"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"[..];
+        let empty_token = Token::new();
+        let partial_sign_fn = if should_blind {
+            partial_sign_blinded_message
+        } else {
+            partial_sign
+        };
+        let partial_verify_fn = if should_blind {
+            partial_verify_blind_signature
+        } else {
+            partial_verify
+        };
 
         let mut keys = MaybeUninit::<*mut Keys>::uninit();
         threshold_keygen(5, 3, &seed[..], keys.as_mut_ptr());
         let keys = unsafe { &*keys.assume_init() };
 
-        // 1. blind the message
-        let mut blinded_message = MaybeUninit::<Buffer>::uninit();
-        let mut blinding_factor = MaybeUninit::<*mut Token<PrivateKey>>::uninit();
-        blind(
-            &Buffer::from(msg.as_ref()),
-            &Buffer::from(user_seed),
-            blinded_message.as_mut_ptr(),
-            blinding_factor.as_mut_ptr(),
-        );
-        let blinded_message = unsafe { blinded_message.assume_init() };
-        let blinding_factor = unsafe { blinding_factor.assume_init() };
+        let (message_to_sign, blinding_factor) = if should_blind {
+            let mut blinded_message = MaybeUninit::<Buffer>::uninit();
+            let mut blinding_factor = MaybeUninit::<*mut Token<PrivateKey>>::uninit();
+            blind(
+                &Buffer::from(msg.as_ref()),
+                &Buffer::from(user_seed),
+                blinded_message.as_mut_ptr(),
+                blinding_factor.as_mut_ptr(),
+            );
+            let blinded_message = unsafe { blinded_message.assume_init() };
+            let blinding_factor = unsafe { &*blinding_factor.assume_init() };
+
+            (blinded_message, blinding_factor)
+        } else {
+            (Buffer::from(&msg[..]), &empty_token)
+        };
+
 
         // 2. partially sign the blinded message
         let mut sigs = Vec::new();
         for i in 0..3 {
             let mut partial_sig = MaybeUninit::<Buffer>::uninit();
-            let ret = partial_sign(
+            let ret = partial_sign_fn(
                 share_ptr(keys, i),
-                &blinded_message,
+                &message_to_sign,
                 partial_sig.as_mut_ptr(),
             );
             assert!(ret);
@@ -503,7 +578,7 @@ mod tests {
         let mut concatenated = Vec::new();
         for sig in &sigs {
             concatenated.extend_from_slice(<&[u8]>::from(sig));
-            let ret = partial_verify(public_key, &blinded_message, sig);
+            let ret = partial_verify_fn(public_key, &message_to_sign, sig);
             assert!(ret);
         }
         let concatenated = Buffer::from(&concatenated[..]);
@@ -515,56 +590,79 @@ mod tests {
         let asig = unsafe { asig.assume_init() };
 
         // 5. unblind the threshold signature
-        let mut unblinded = MaybeUninit::<Buffer>::uninit();
-        let ret = unblind(&asig, blinding_factor, unblinded.as_mut_ptr());
-        assert!(ret);
-        let unblinded = unsafe { unblinded.assume_init() };
+        let asig = if should_blind {
+            let mut unblinded = MaybeUninit::<Buffer>::uninit();
+            let ret = unblind(&asig, blinding_factor, unblinded.as_mut_ptr());
+            assert!(ret);
+            unsafe { unblinded.assume_init() }
+        } else {
+            asig
+        };
 
         // 6. verify the threshold signature against the public key
         let ret = verify(
             threshold_public_key_ptr(keys),
             &Buffer::from(&msg[..]),
-            &unblinded,
+            &asig,
         );
         assert!(ret);
     }
 
     #[test]
-    fn blinded_ffi() {
+    fn verify_ffi() {
+        verify_ffi_should_blind(true);
+        verify_ffi_should_blind(false);
+    }
+
+    fn verify_ffi_should_blind(should_blind: bool) {
         let seed = b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         let msg = vec![1u8, 2, 3, 4, 6];
         let user_seed = &b"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"[..];
+        let empty_token = Token::new();
+
+        let sign_fn = if should_blind {
+            sign_blinded_message
+        } else {
+            sign
+        };
 
         let mut keypair = MaybeUninit::<*mut Keypair>::uninit();
         keygen(&Buffer::from(&seed[..]), keypair.as_mut_ptr());
         let keypair = unsafe { &*keypair.assume_init() };
 
-        // 1. blind the message
-        let mut blinded_message = MaybeUninit::<Buffer>::uninit();
-        let mut blinding_factor = MaybeUninit::<*mut Token<PrivateKey>>::uninit();
-        blind(
-            &Buffer::from(msg.as_ref()),
-            &Buffer::from(user_seed),
-            blinded_message.as_mut_ptr(),
-            blinding_factor.as_mut_ptr(),
-        );
-        let blinded_message = unsafe { blinded_message.assume_init() };
-        let blinding_factor = unsafe { blinding_factor.assume_init() };
+        let (message_to_sign, blinding_factor) = if should_blind {
+            let mut blinded_message = MaybeUninit::<Buffer>::uninit();
+            let mut blinding_factor = MaybeUninit::<*mut Token<PrivateKey>>::uninit();
+            blind(
+                &Buffer::from(msg.as_ref()),
+                &Buffer::from(user_seed),
+                blinded_message.as_mut_ptr(),
+                blinding_factor.as_mut_ptr(),
+            );
+            let blinded_message = unsafe { blinded_message.assume_init() };
+            let blinding_factor = unsafe { &*blinding_factor.assume_init() };
 
-        // 2. sign the blinded message
+            (blinded_message, blinding_factor)
+        } else {
+            (Buffer::from(&msg[..]), &empty_token)
+        };
+
         let mut sig = MaybeUninit::<Buffer>::uninit();
-        let ret = sign(private_key_ptr(keypair), &blinded_message, sig.as_mut_ptr());
+        let ret = sign_fn(private_key_ptr(keypair), &message_to_sign, sig.as_mut_ptr());
         assert!(ret);
         let sig = unsafe { sig.assume_init() };
 
-        // 4. unblind the signature
-        let mut unblinded = MaybeUninit::<Buffer>::uninit();
-        let ret = unblind(&sig, blinding_factor, unblinded.as_mut_ptr());
-        assert!(ret);
-        let unblinded = unsafe { unblinded.assume_init() };
+        let sig = if should_blind {
+            let mut unblinded = MaybeUninit::<Buffer>::uninit();
+            let ret = unblind(&sig, blinding_factor, unblinded.as_mut_ptr());
+            assert!(ret);
 
-        // 4. verify the signature
-        let ret = verify(public_key_ptr(keypair), &Buffer::from(&msg[..]), &unblinded);
+            unsafe { unblinded.assume_init() }
+        } else {
+            sig
+        };
+
+        let ret = verify(public_key_ptr(keypair), &Buffer::from(&msg[..]), &sig);
         assert!(ret);
     }
 

--- a/crates/threshold-bls-ffi/src/ffi.rs
+++ b/crates/threshold-bls-ffi/src/ffi.rs
@@ -557,7 +557,6 @@ mod tests {
             (Buffer::from(&msg[..]), &empty_token)
         };
 
-
         // 2. partially sign the blinded message
         let mut sigs = Vec::new();
         for i in 0..3 {

--- a/crates/threshold-bls-ffi/src/wasm.rs
+++ b/crates/threshold-bls-ffi/src/wasm.rs
@@ -6,7 +6,7 @@ use rand_core::{RngCore, SeedableRng};
 
 use threshold_bls::{
     curve::zexe::PairingCurve as Bls12_377,
-    group::{Element, Encodable, Point},
+    group::{Element, Encodable},
     poly::Poly,
     sig::{blind::Token, bls::G2Scheme, Blinder, Scheme, SignatureScheme, ThresholdScheme},
     Index, Share,
@@ -86,13 +86,8 @@ pub fn verify(public_key_buf: &[u8], message: &[u8], signature: &[u8]) -> Result
         .unmarshal(&public_key_buf)
         .map_err(|err| JsValue::from_str(&format!("could not unmarshal public key {}", err)))?;
 
-    // hashes the message
-    let mut msg_hash = Signature::new();
-    msg_hash.map(&message).unwrap();
-    let msg_hash = msg_hash.marshal();
-
     // checks the signature on the message hash
-    <SigScheme as SignatureScheme>::verify(&public_key, &msg_hash, &signature)
+    <SigScheme as SignatureScheme>::verify(&public_key, &message, &signature)
         .map_err(|err| JsValue::from_str(&format!("signature verification failed: {}", err)))
 }
 
@@ -136,6 +131,26 @@ pub fn partial_sign(share_buf: &[u8], message: &[u8]) -> Result<Vec<u8>> {
         .map_err(|err| JsValue::from_str(&format!("could not partially sign message: {}", err)))
 }
 
+#[wasm_bindgen(js_name = partialSignBlindedMessage)]
+/// Signs the message with the provided **share** of the private key and returns the **partial**
+/// signature.
+///
+/// # Throws
+///
+/// - If signing fails
+///
+/// NOTE: This method must NOT be called with a PrivateKey which is not generated via a
+/// secret sharing scheme.
+pub fn partial_sign_blinded_message(share_buf: &[u8], message: &[u8]) -> Result<Vec<u8>> {
+    let mut share = Share::<PrivateKey>::new(0, PrivateKey::new());
+    share.unmarshal(&share_buf).map_err(|err| {
+        JsValue::from_str(&format!("could not unmarshal private key share {}", err))
+    })?;
+
+    SigScheme::partial_sign_without_hashing(&share, &message)
+        .map_err(|err| JsValue::from_str(&format!("could not partially sign message: {}", err)))
+}
+
 ///////////////////////////////////////////////////////////////////////////
 // Combiner -> Library
 ///////////////////////////////////////////////////////////////////////////
@@ -154,6 +169,27 @@ pub fn partial_verify(polynomial_buf: &[u8], blinded_message: &[u8], sig: &[u8])
         .map_err(|err| JsValue::from_str(&format!("could not unmarshal polynomial {}", err)))?;
 
     SigScheme::partial_verify(&polynomial, blinded_message, sig)
+        .map_err(|err| JsValue::from_str(&format!("could not partially verify message: {}", err)))
+}
+
+#[wasm_bindgen(js_name = partialVerifyBlindSignature)]
+/// Verifies a partial *blind* signature against the public key corresponding to the secret shared
+/// polynomial.
+///
+/// # Throws
+///
+/// - If verification fails
+pub fn partial_verify_blind_signature(
+    polynomial_buf: &[u8],
+    blinded_message: &[u8],
+    sig: &[u8],
+) -> Result<()> {
+    let mut polynomial = Poly::<PrivateKey, PublicKey>::from(vec![]);
+    polynomial
+        .unmarshal(&polynomial_buf)
+        .map_err(|err| JsValue::from_str(&format!("could not unmarshal polynomial {}", err)))?;
+
+    SigScheme::partial_verify_without_hashing(&polynomial, blinded_message, sig)
         .map_err(|err| JsValue::from_str(&format!("could not partially verify message: {}", err)))
 }
 
@@ -333,6 +369,27 @@ mod tests {
     use super::*;
 
     #[test]
+    fn threshold_wasm() {
+        let seed = b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let keys = threshold_keygen(5, 3, &seed[..]);
+
+        let msg = vec![1, 2, 3, 4, 6];
+
+        let sig1 = partial_sign(&keys.get_share(0), &msg).unwrap();
+        let sig2 = partial_sign(&keys.get_share(1), &msg).unwrap();
+        let sig3 = partial_sign(&keys.get_share(2), &msg).unwrap();
+
+        partial_verify(&keys.polynomial(), &msg, &sig1).unwrap();
+        partial_verify(&keys.polynomial(), &msg, &sig2).unwrap();
+        partial_verify(&keys.polynomial(), &msg, &sig3).unwrap();
+
+        let concatenated = [sig1, sig2, sig3].concat();
+        let asig = combine(3, concatenated).unwrap();
+
+        verify(&keys.threshold_public_key(), &msg, &asig).unwrap();
+    }
+
+    #[test]
     fn blinded_threshold_wasm() {
         let seed = b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         let keys = threshold_keygen(5, 3, &seed[..]);
@@ -342,13 +399,13 @@ mod tests {
         let blinded_message = blind(msg.clone(), &key[..]);
         let blinded_msg = blinded_message.message.clone();
 
-        let sig1 = partial_sign(&keys.get_share(0), &blinded_msg).unwrap();
-        let sig2 = partial_sign(&keys.get_share(1), &blinded_msg).unwrap();
-        let sig3 = partial_sign(&keys.get_share(2), &blinded_msg).unwrap();
+        let sig1 = partial_sign_blinded_message(&keys.get_share(0), &blinded_msg).unwrap();
+        let sig2 = partial_sign_blinded_message(&keys.get_share(1), &blinded_msg).unwrap();
+        let sig3 = partial_sign_blinded_message(&keys.get_share(2), &blinded_msg).unwrap();
 
-        partial_verify(&keys.polynomial(), &blinded_msg, &sig1).unwrap();
-        partial_verify(&keys.polynomial(), &blinded_msg, &sig2).unwrap();
-        partial_verify(&keys.polynomial(), &blinded_msg, &sig3).unwrap();
+        partial_verify_blind_signature(&keys.polynomial(), &blinded_msg, &sig1).unwrap();
+        partial_verify_blind_signature(&keys.polynomial(), &blinded_msg, &sig2).unwrap();
+        partial_verify_blind_signature(&keys.polynomial(), &blinded_msg, &sig3).unwrap();
 
         let concatenated = [sig1, sig2, sig3].concat();
         let asig = combine(3, concatenated).unwrap();

--- a/crates/threshold-bls-ffi/src/wasm.rs
+++ b/crates/threshold-bls-ffi/src/wasm.rs
@@ -8,7 +8,10 @@ use threshold_bls::{
     curve::zexe::PairingCurve as Bls12_377,
     group::{Element, Encodable},
     poly::Poly,
-    sig::{blind::Token, bls::G2Scheme, Blinder, Scheme, SignatureScheme, ThresholdScheme},
+    sig::{
+        blind::Token, bls::G2Scheme, Blinder, Scheme, SignatureScheme, ThresholdScheme,
+        ThresholdSchemeExt,
+    },
     Index, Share,
 };
 

--- a/crates/threshold-bls/src/sig/blind.rs
+++ b/crates/threshold-bls/src/sig/blind.rs
@@ -108,13 +108,12 @@ mod tests {
         let msg = vec![1, 9, 6, 9];
 
         let (token, blinded) = B::blind(&msg, &mut thread_rng());
-        let blinded_sig = B::sign(&private, &blinded).unwrap();
+
+        // signs the blinded message w/o hashing
+        let blinded_sig = B::sign_without_hashing(&private, &blinded).unwrap();
+
         let clear_sig = B::unblind(&token, &blinded_sig).expect("unblind should go well");
 
-        let mut msg_point = B::Signature::new();
-        msg_point.map(&msg).unwrap();
-        let msg_point_bytes = msg_point.marshal();
-
-        B::verify(&public, &msg_point_bytes, &clear_sig).unwrap();
+        B::verify(&public, &msg, &clear_sig).unwrap();
     }
 }

--- a/crates/threshold-bls/src/sig/blind.rs
+++ b/crates/threshold-bls/src/sig/blind.rs
@@ -1,5 +1,5 @@
 use crate::group::{Element, Encodable, Point, Scalar};
-use crate::sig::{BlindScheme, Blinder, SignatureScheme};
+use crate::sig::{BlindScheme, Blinder, SignatureScheme, SignatureSchemeExt};
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -46,7 +46,7 @@ impl<S: Scalar> Encodable for Token<S> {
 
 // We implement Blinder for anything that implements Signature scheme, so we also
 // enable the BlindScheme for all these, for convenience
-impl<I> BlindScheme for I where I: SignatureScheme {}
+impl<I> BlindScheme for I where I: SignatureSchemeExt {}
 
 /// The blinder follows the protocol described
 /// in this [paper](https://eprint.iacr.org/2018/733.pdf).

--- a/crates/threshold-bls/src/sig/bls.rs
+++ b/crates/threshold-bls/src/sig/bls.rs
@@ -1,5 +1,5 @@
 use crate::group::{Element, Encodable, PairingCurve, Point};
-use crate::sig::{Scheme, SignatureScheme};
+use crate::sig::{Scheme, SignatureScheme, SignatureSchemeExt};
 use std::{fmt::Debug, marker::PhantomData};
 use thiserror::Error;
 
@@ -83,13 +83,6 @@ mod common {
             T::internal_sign(private, msg, true)
         }
 
-        fn sign_without_hashing(
-            private: &Self::Private,
-            msg: &[u8],
-        ) -> Result<Vec<u8>, Self::Error> {
-            T::internal_sign(private, msg, false)
-        }
-
         /// Verifies the signature by the provided public key
         fn verify(
             public: &Self::Public,
@@ -97,6 +90,18 @@ mod common {
             sig_bytes: &[u8],
         ) -> Result<(), Self::Error> {
             T::internal_verify(public, msg_bytes, sig_bytes, true)
+        }
+    }
+
+    impl<T> SignatureSchemeExt for T
+    where
+        T: BLSScheme,
+    {
+        fn sign_without_hashing(
+            private: &Self::Private,
+            msg: &[u8],
+        ) -> Result<Vec<u8>, Self::Error> {
+            T::internal_sign(private, msg, false)
         }
 
         fn verify_without_hashing(

--- a/crates/threshold-bls/src/sig/sig.rs
+++ b/crates/threshold-bls/src/sig/sig.rs
@@ -44,13 +44,10 @@ pub trait Scheme: Debug {
 ///
 ///
 ///  let msg = vec![1,9,6,9];
-///  let mut msg_point = <G2Scheme::<PC> as Scheme>::Signature::new();
-///  msg_point.map(&msg).unwrap();
-///  let msg_point_bytes = msg_point.marshal();
 ///
 ///  let (private,public) = G2Scheme::<PC>::keypair(&mut thread_rng());
-///  let signature = G2Scheme::<PC>::sign(&private,&msg_point_bytes).unwrap();
-///  match G2Scheme::<PC>::verify(&public,&msg_point_bytes,&signature) {
+///  let signature = G2Scheme::<PC>::sign(&private,&msg).unwrap();
+///  match G2Scheme::<PC>::verify(&public, &msg, &signature) {
 ///     Ok(_) => println!("signature is correct!"),
 ///     Err(e) => println!("signature is invalid: {}",e),
 ///  };
@@ -61,6 +58,7 @@ pub trait SignatureScheme: Scheme {
     type Error: Error;
 
     fn sign(private: &Self::Private, msg: &[u8]) -> Result<Vec<u8>, Self::Error>;
+    fn sign_without_hashing(private: &Self::Private, msg: &[u8]) -> Result<Vec<u8>, Self::Error>;
     fn verify(public: &Self::Public, msg: &[u8], sig: &[u8]) -> Result<(), Self::Error>;
 }
 
@@ -93,6 +91,12 @@ pub trait ThresholdScheme: Scheme {
     type Error: Error;
 
     fn partial_sign(private: &Share<Self::Private>, msg: &[u8]) -> Result<Partial, Self::Error>;
+
+    fn partial_sign_without_hashing(
+        private: &Share<Self::Private>,
+        msg: &[u8],
+    ) -> Result<Partial, Self::Error>;
+
     fn partial_verify(
         public: &Poly<Self::Private, Self::Public>,
         msg: &[u8],

--- a/crates/threshold-bls/src/sig/sig.rs
+++ b/crates/threshold-bls/src/sig/sig.rs
@@ -58,8 +58,16 @@ pub trait SignatureScheme: Scheme {
     type Error: Error;
 
     fn sign(private: &Self::Private, msg: &[u8]) -> Result<Vec<u8>, Self::Error>;
+
     fn sign_without_hashing(private: &Self::Private, msg: &[u8]) -> Result<Vec<u8>, Self::Error>;
+
     fn verify(public: &Self::Public, msg: &[u8], sig: &[u8]) -> Result<(), Self::Error>;
+
+    fn verify_without_hashing(
+        public: &Self::Public,
+        msg: &[u8],
+        sig: &[u8],
+    ) -> Result<(), Self::Error>;
 }
 
 /// Blinder holds the functionality of blinding and unblinding a message. It is
@@ -98,6 +106,12 @@ pub trait ThresholdScheme: Scheme {
     ) -> Result<Partial, Self::Error>;
 
     fn partial_verify(
+        public: &Poly<Self::Private, Self::Public>,
+        msg: &[u8],
+        partial: &[u8],
+    ) -> Result<(), Self::Error>;
+
+    fn partial_verify_without_hashing(
         public: &Poly<Self::Private, Self::Public>,
         msg: &[u8],
         partial: &[u8],

--- a/crates/threshold-bls/src/sig/tblind.rs
+++ b/crates/threshold-bls/src/sig/tblind.rs
@@ -39,9 +39,9 @@ mod tests {
     #[cfg(feature = "bls12_377")]
     use crate::curve::zexe::PairingCurve as Zexe;
     use crate::sig::bls::{G1Scheme, G2Scheme};
+    use crate::Index;
     use crate::{poly::Poly, Share};
     use rand::thread_rng;
-    use crate::Index;
 
     fn shares<B: BlindThresholdScheme>(
         n: usize,

--- a/crates/threshold-bls/src/sig/tblind.rs
+++ b/crates/threshold-bls/src/sig/tblind.rs
@@ -41,11 +41,8 @@ mod tests {
     use crate::sig::bls::{G1Scheme, G2Scheme};
     use crate::{poly::Poly, Share};
     use rand::thread_rng;
+    use crate::Index;
 
-    use crate::{
-        group::{Element, Encodable, Point},
-        Index,
-    };
     fn shares<B: BlindThresholdScheme>(
         n: usize,
         t: usize,
@@ -97,15 +94,10 @@ mod tests {
         // blind the msg
         let (token, blinded) = B::blind(&msg, &mut thread_rng());
 
-        // hash it
-        let mut msg_point = B::Signature::new();
-        msg_point.map(&msg).unwrap();
-        let msg_point_bytes = msg_point.marshal();
-
         // partially sign it
         let partials: Vec<_> = shares
             .iter()
-            .map(|share| B::partial_sign(share, &blinded).unwrap())
+            .map(|share| B::partial_sign_without_hashing(share, &blinded).unwrap())
             .collect();
 
         // unblind each partial sig
@@ -120,6 +112,6 @@ mod tests {
         // aggregate
         let final_sig = B::aggregate(thr, &unblindeds).unwrap();
 
-        B::verify(&public.public_key(), &msg_point_bytes, &final_sig).unwrap();
+        B::verify(&public.public_key(), &msg, &final_sig).unwrap();
     }
 }

--- a/crates/threshold-bls/src/sig/tblind.rs
+++ b/crates/threshold-bls/src/sig/tblind.rs
@@ -1,5 +1,5 @@
 use crate::sig::tbls::{IndexSerializerError, Serializer};
-use crate::sig::{BlindThresholdScheme, Blinder, Partial, ThresholdScheme};
+use crate::sig::{BlindThresholdScheme, Blinder, Partial, ThresholdSchemeExt};
 
 use thiserror::Error;
 
@@ -14,7 +14,7 @@ pub enum BlindThresholdError<E: 'static + std::error::Error> {
 
 impl<T> BlindThresholdScheme for T
 where
-    T: 'static + ThresholdScheme + Blinder + Serializer,
+    T: 'static + ThresholdSchemeExt + Blinder + Serializer,
 {
     type Error = BlindThresholdError<<T as Blinder>::Error>;
 

--- a/crates/threshold-bls/src/sig/tbls.rs
+++ b/crates/threshold-bls/src/sig/tbls.rs
@@ -74,6 +74,17 @@ impl<I: SignatureScheme> ThresholdScheme for I {
         Self::verify(&public_i.value, msg, &bls_sig).map_err(ThresholdError::SignatureError)
     }
 
+    fn partial_verify_without_hashing(
+        public: &Poly<Self::Private, Self::Public>,
+        msg: &[u8],
+        partial: &[u8],
+    ) -> Result<(), <Self as ThresholdScheme>::Error> {
+        let (idx, bls_sig) = extract_index(partial)?;
+        let public_i = public.eval(idx);
+        Self::verify_without_hashing(&public_i.value, msg, &bls_sig)
+            .map_err(ThresholdError::SignatureError)
+    }
+
     fn aggregate(
         threshold: usize,
         partials: &[Partial],

--- a/crates/threshold-bls/src/sig/tbls.rs
+++ b/crates/threshold-bls/src/sig/tbls.rs
@@ -1,7 +1,9 @@
 //! Implements Threshold Signatures for all Signature Scheme implementers
 use crate::group::{Element, Encodable};
 use crate::poly::{Eval, Poly, PolyError};
-use crate::sig::{Partial, SignatureScheme, ThresholdScheme};
+use crate::sig::{
+    Partial, SignatureScheme, SignatureSchemeExt, ThresholdScheme, ThresholdSchemeExt,
+};
 use crate::{Index, Share};
 use std::{convert::TryInto, fmt::Debug};
 use thiserror::Error;
@@ -54,16 +56,6 @@ impl<I: SignatureScheme> ThresholdScheme for I {
         Ok(ret)
     }
 
-    fn partial_sign_without_hashing(
-        private: &Share<Self::Private>,
-        msg: &[u8],
-    ) -> Result<Vec<u8>, <Self as ThresholdScheme>::Error> {
-        let mut sig = Self::sign_without_hashing(&private.private, msg)
-            .map_err(ThresholdError::SignatureError)?;
-        let ret = inject_index(private.index, &mut sig);
-        Ok(ret)
-    }
-
     fn partial_verify(
         public: &Poly<Self::Private, Self::Public>,
         msg: &[u8],
@@ -72,17 +64,6 @@ impl<I: SignatureScheme> ThresholdScheme for I {
         let (idx, bls_sig) = extract_index(partial)?;
         let public_i = public.eval(idx);
         Self::verify(&public_i.value, msg, &bls_sig).map_err(ThresholdError::SignatureError)
-    }
-
-    fn partial_verify_without_hashing(
-        public: &Poly<Self::Private, Self::Public>,
-        msg: &[u8],
-        partial: &[u8],
-    ) -> Result<(), <Self as ThresholdScheme>::Error> {
-        let (idx, bls_sig) = extract_index(partial)?;
-        let public_i = public.eval(idx);
-        Self::verify_without_hashing(&public_i.value, msg, &bls_sig)
-            .map_err(ThresholdError::SignatureError)
     }
 
     fn aggregate(
@@ -127,6 +108,29 @@ impl<I: SignatureScheme> ThresholdScheme for I {
     }
 }
 
+impl<I: SignatureSchemeExt> ThresholdSchemeExt for I {
+    fn partial_sign_without_hashing(
+        private: &Share<Self::Private>,
+        msg: &[u8],
+    ) -> Result<Vec<u8>, <Self as ThresholdScheme>::Error> {
+        let mut sig = Self::sign_without_hashing(&private.private, msg)
+            .map_err(ThresholdError::SignatureError)?;
+        let ret = inject_index(private.index, &mut sig);
+        Ok(ret)
+    }
+
+    fn partial_verify_without_hashing(
+        public: &Poly<Self::Private, Self::Public>,
+        msg: &[u8],
+        partial: &[u8],
+    ) -> Result<(), <Self as ThresholdScheme>::Error> {
+        let (idx, bls_sig) = extract_index(partial)?;
+        let public_i = public.eval(idx);
+        Self::verify_without_hashing(&public_i.value, msg, &bls_sig)
+            .map_err(ThresholdError::SignatureError)
+    }
+}
+
 fn inject_index(index: Index, sig: &[u8]) -> Vec<u8> {
     let mut res = index.to_le_bytes().to_vec();
     res.extend_from_slice(sig);
@@ -149,7 +153,6 @@ fn extract_index(sig: &[u8]) -> Result<(Index, Vec<u8>), IndexSerializerError> {
 mod tests {
     use super::*;
     use crate::curve::bls12381::PairingCurve as PCurve;
-    use crate::group::{Encodable, Point};
     use crate::sig::{
         bls::{G1Scheme, G2Scheme},
         Scheme,


### PR DESCRIPTION
This allows us to have an intuitive API:

- sign: call whenever you are signing a message
- sign_without_hashing: call whenever you receive a blinded message since it's already hashed and multiplied with the user's scalar.