### PR TITLE
Adding method to verify a partial blind signature with blinded message 

### DIFF
--- a/crates/threshold-bls/src/sig/blind.rs
+++ b/crates/threshold-bls/src/sig/blind.rs
@@ -1,8 +1,10 @@
 use crate::group::{Element, Encodable, Point, Scalar};
-use crate::sig::{BlindScheme, Blinder, SignatureScheme};
+use crate::sig::bls::common;
+use crate::sig::{BlindScheme, Blinder, SignatureScheme,Scheme};
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use std::error;
 
 /// BlindError are a type of errors that blind signature scheme can return.
 #[derive(Debug, Error)]
@@ -14,6 +16,9 @@ pub enum BlinderError<E: Encodable + std::fmt::Debug> {
     InvalidToken,
     #[error("could not deserialize scalar: {0}")]
     EncodableError(E::Error),
+
+    #[error("invalid blinded point")]
+    InvalidBlinding,
 }
 
 /// Blinding a message before requesting a signature requires the usage of a
@@ -44,22 +49,54 @@ impl<S: Scalar> Encodable for Token<S> {
     }
 }
 
+pub trait BlindVerifier : Scheme {
+    type Error : error::Error;
+    fn private_blind_verify(public: &Self::Public, blinded_msg: &[u8], blinded_sig: &[u8]) -> Result<(), String>;
+}
+
+impl<B> BlindVerifier for B where B: Blinder + Scheme + common::BLSScheme {
+    type Error = <B as Blinder>::Error;
+    fn private_blind_verify(public: &Self::Public, blinded_msg: &[u8], blinded_sig: &[u8]) -> Result<(), String> {
+        // message point
+        let mut hm = B::Signature::new();
+        if let Err(_) =  hm.unmarshal(blinded_msg) {
+            //return Err(BlinderError::InvalidBlinding);
+            return Err(String::from("message invalid point"));
+        }
+        // signature point
+        let mut hs  = B::Signature::new();
+        if let Err(_) = hs.unmarshal(blinded_sig) {
+            //return Err(BlinderError::InvalidBlinding);
+            return Err(String::from("signature invalid point"));
+        }
+
+        if B::final_exp(public,&hs,&hm) {
+            return Ok(());
+        } else {
+            //return Err(BlinderError::InvalidBlinding);
+            return Err(String::from("signature invalid"));
+        }
+    }
+}
+
 // We implement BlindScheme for anything that is both a blinder and a scheme. We
 // don't take a regular Signature since the signing process isn't the same
-impl<B> BlindScheme for B where B: Blinder + Scheme  {
-    fn sign(private: &Self::Private, blinded: &[u8]) -> Result<Vec<u8>, Self::Error> {
-    let mut hm = I::Signature::new();
-        match hm.unmarshal(blinded) {
+impl<B> BlindScheme for B where B: Blinder + Scheme  + BlindVerifier {
+    fn verify_blind(public: &B::Public, blinded_msg: &[u8], blinded_sig: &[u8]) -> Result<(), String> {
+        B::private_blind_verify(public,blinded_msg,blinded_sig)
+    }
+
+    fn sign_blind(private: &B::Private, blinded_msg: &[u8]) -> Result<Vec<u8>, String> {
+        // (r * H(m))^x
+        let mut hm = B::Signature::new();
+        match hm.unmarshal(blinded_msg) {
             Ok(()) => {
                 hm.mul(private);
                 Ok(hm.marshal())
             }
-            Err(e) => Err(e),
+            //Err(e) => BlinderError::EncodableError(e),
+            Err(e) => Err(String::from("encodable error")),
         }
-
-    }
-    fn verify(public: &Self::Public, msg: &[u8], sig: &[u8]) -> Result<(), Self::Error> {
-        I::verify(public,msg,sig)
     }
 }
 
@@ -123,13 +160,12 @@ mod tests {
         let msg = vec![1, 9, 6, 9];
 
         let (token, blinded) = B::blind(&msg, &mut thread_rng());
-        let blinded_sig = B::sign(&private, &blinded).unwrap();
+        let blinded_sig = B::sign_blind(&private, &blinded).unwrap();
         let clear_sig = B::unblind(&token, &blinded_sig).expect("unblind should go well");
-
-        let mut msg_point = B::Signature::new();
-        msg_point.map(&msg).unwrap();
-        let msg_point_bytes = msg_point.marshal();
-
-        B::verify(&public, &msg_point_bytes, &clear_sig).unwrap();
+        //verify_blind(&public, &blinded, &blinded_sig).unwrap();
+        match B::verify_blind(&public, &msg, &clear_sig) {
+            Ok(()) => {},
+            Err(e) => println!("{:?}",e),
+        }
     }
 }

--- a/crates/threshold-bls/src/sig/blind.rs
+++ b/crates/threshold-bls/src/sig/blind.rs
@@ -44,9 +44,24 @@ impl<S: Scalar> Encodable for Token<S> {
     }
 }
 
-// We implement Blinder for anything that implements Signature scheme, so we also
-// enable the BlindScheme for all these, for convenience
-impl<I> BlindScheme for I where I: SignatureScheme {}
+// We implement BlindScheme for anything that is both a blinder and a scheme. We
+// don't take a regular Signature since the signing process isn't the same
+impl<B> BlindScheme for B where B: Blinder + Scheme  {
+    fn sign(private: &Self::Private, blinded: &[u8]) -> Result<Vec<u8>, Self::Error> {
+    let mut hm = I::Signature::new();
+        match hm.unmarshal(blinded) {
+            Ok(()) => {
+                hm.mul(private);
+                Ok(hm.marshal())
+            }
+            Err(e) => Err(e),
+        }
+
+    }
+    fn verify(public: &Self::Public, msg: &[u8], sig: &[u8]) -> Result<(), Self::Error> {
+        I::verify(public,msg,sig)
+    }
+}
 
 /// The blinder follows the protocol described
 /// in this [paper](https://eprint.iacr.org/2018/733.pdf).

--- a/crates/threshold-bls/src/sig/mod.rs
+++ b/crates/threshold-bls/src/sig/mod.rs
@@ -1,6 +1,6 @@
-//pub mod blind;
+pub mod blind;
 pub mod bls;
 mod sig;
-//pub mod tblind;
-//pub mod tbls;
+pub mod tblind;
+pub mod tbls;
 pub use sig::*;

--- a/crates/threshold-bls/src/sig/mod.rs
+++ b/crates/threshold-bls/src/sig/mod.rs
@@ -1,6 +1,6 @@
-pub mod blind;
+//pub mod blind;
 pub mod bls;
 mod sig;
-pub mod tblind;
-pub mod tbls;
+//pub mod tblind;
+//pub mod tbls;
 pub use sig::*;

--- a/crates/threshold-bls/src/sig/sig.rs
+++ b/crates/threshold-bls/src/sig/sig.rs
@@ -79,7 +79,11 @@ pub trait Blinder {
 /// signature so the signer does not know the real message. The signature can
 /// later be "unblinded" as to reveal a valid signature over the initial
 /// message.
-pub trait BlindScheme: SignatureScheme + Blinder {}
+pub trait BlindScheme: Scheme + Blinder {
+    fn blind_sign(private: &Self::Private, blind_msg :&[u8]) -> Result<Vec<u8>,Self::Error>;
+    fn blind_verify(public: &Self::Public, blinded_msg: &[u8], sig: &[u8]) -> Result<(), Self::Error>;
+    fn verify(public: &Self::Public, msg: &[u8], sig: &[u8]) -> Result<(), Self::Error>;
+}
 
 /// Partial is simply an alias to denote a partial signature.
 pub type Partial = Vec<u8>;

--- a/crates/threshold-bls/src/sig/sig.rs
+++ b/crates/threshold-bls/src/sig/sig.rs
@@ -66,7 +66,7 @@ pub trait SignatureScheme: Scheme {
 
 /// Blinder holds the functionality of blinding and unblinding a message. It is
 /// not to be used alone but in combination with a signature scheme or a
-/// threshold scheme.
+/// threshold scheme or to build a blindscheme.
 pub trait Blinder {
     type Token: Encodable;
     type Error: Error;
@@ -79,10 +79,11 @@ pub trait Blinder {
 /// signature so the signer does not know the real message. The signature can
 /// later be "unblinded" as to reveal a valid signature over the initial
 /// message.
-pub trait BlindScheme: Scheme + Blinder {
-    fn blind_sign(private: &Self::Private, blind_msg :&[u8]) -> Result<Vec<u8>,Self::Error>;
-    fn blind_verify(public: &Self::Public, blinded_msg: &[u8], sig: &[u8]) -> Result<(), Self::Error>;
-    fn verify(public: &Self::Public, msg: &[u8], sig: &[u8]) -> Result<(), Self::Error>;
+pub trait BlindScheme: Blinder + Scheme {
+    //fn sign_blind(private: &Self::Private, blinded_msg: &[u8]) -> Result<Vec<u8>, <Self as Blinder>::Error>;
+    fn sign_blind(private: &Self::Private, blinded_msg: &[u8]) -> Result<Vec<u8>, String>;
+    //fn verify_blind(public: &Self::Public, blinded_msg: &[u8], blinded_sig: &[u8]) -> Result<(), <Self as Blinder>::Error>;
+    fn verify_blind(public: &Self::Public, blinded_msg: &[u8], blinded_sig: &[u8]) -> Result<(), String>;
 }
 
 /// Partial is simply an alias to denote a partial signature.
@@ -123,4 +124,9 @@ pub trait BlindThresholdScheme: ThresholdScheme + Blinder {
         t: &Self::Token,
         partial: &Partial,
     ) -> Result<Partial, <Self as BlindThresholdScheme>::Error>;
+
+    fn partial_verify_blind( public: &Poly<Self::Private, Self::Public>,
+        blinded_msg: &[u8],
+        blinded_partial: &Partial,
+    ) -> Result<(), String>;
 }


### PR DESCRIPTION
This PR is an attempt (so far failing) to use the current code to add a `verify blinded partial` method to the `BlindThresholdScheme` without exposing any unnecessary API methods.

Attempt is failing so far because we need to be able to override the ThresholdScheme::sign behavior to use `BlindScheme::sign_blind`. 

Maybe is it possible to create yet another trait (that don't need to be exposed publicly) that takes care of the `signing` behavior of `ThresholdScheme` and we can implement it differently for `ThresholdBlind` ? Unclear to me yet...

**NOTE**: This PR is PoC, so in the spirit of speed, errors are just String - it wasn't clear to me how correctly bind a new error trait bound etc ... 