### PR TITLE
Remove Encodable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,9 +1210,11 @@ dependencies = [
 name = "threshold-bls-ffi"
 version = "0.1.0"
 dependencies = [
+ "bincode",
  "bls-crypto",
  "rand_chacha",
  "rand_core",
+ "serde",
  "threshold-bls",
  "wasm-bindgen",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1191,6 +1191,7 @@ name = "threshold-bls"
 version = "0.1.0"
 dependencies = [
  "algebra",
+ "bincode",
  "bls-crypto",
  "chacha20poly1305",
  "fff",

--- a/crates/threshold-bls-ffi/Cargo.toml
+++ b/crates/threshold-bls-ffi/Cargo.toml
@@ -16,6 +16,8 @@ rand_core = { version = "0.5.1", default-features = false }
 rand_chacha = { version = "0.2.2", default-features = false }
 
 wasm-bindgen = { version = "0.2.60", optional = true }
+bincode = { version = "1.2.1", default-features = false }
+serde = { version = "1.0.106", default-features =  false }
 
 [features]
 wasm = ["wasm-bindgen"]

--- a/crates/threshold-bls-ffi/src/lib.rs
+++ b/crates/threshold-bls-ffi/src/lib.rs
@@ -2,3 +2,21 @@ pub mod ffi;
 
 #[cfg(feature = "wasm")]
 pub mod wasm;
+
+use threshold_bls::{
+    curve::zexe::PairingCurve as Bls12_377,
+    sig::{bls::G2Scheme, Scheme},
+    Index,
+};
+
+pub(crate) type SigScheme = G2Scheme<Bls12_377>;
+pub(crate) type PublicKey = <SigScheme as Scheme>::Public;
+pub(crate) type PrivateKey = <SigScheme as Scheme>::Private;
+pub(crate) type Signature = <SigScheme as Scheme>::Signature;
+
+pub(crate) const VEC_LENGTH: usize = 8;
+pub(crate) const SIGNATURE_LEN: usize = VEC_LENGTH + 48;
+pub(crate) const PUBKEY_LEN: usize = VEC_LENGTH + 96;
+pub(crate) const PRIVKEY_LEN: usize = VEC_LENGTH + 32;
+pub(crate) const PARTIAL_SIG_LENGTH: usize =
+    VEC_LENGTH + SIGNATURE_LEN + std::mem::size_of::<Index>();

--- a/crates/threshold-bls-ffi/src/lib.rs
+++ b/crates/threshold-bls-ffi/src/lib.rs
@@ -15,8 +15,8 @@ pub(crate) type PrivateKey = <SigScheme as Scheme>::Private;
 pub(crate) type Signature = <SigScheme as Scheme>::Signature;
 
 pub(crate) const VEC_LENGTH: usize = 8;
-pub(crate) const SIGNATURE_LEN: usize = VEC_LENGTH + 48;
-pub(crate) const PUBKEY_LEN: usize = VEC_LENGTH + 96;
-pub(crate) const PRIVKEY_LEN: usize = VEC_LENGTH + 32;
+pub(crate) const SIGNATURE_LEN: usize = 48;
+pub(crate) const PUBKEY_LEN: usize = 96;
+pub(crate) const PRIVKEY_LEN: usize = 32;
 pub(crate) const PARTIAL_SIG_LENGTH: usize =
     VEC_LENGTH + SIGNATURE_LEN + std::mem::size_of::<Index>();

--- a/crates/threshold-bls/Cargo.toml
+++ b/crates/threshold-bls/Cargo.toml
@@ -27,6 +27,7 @@ groupy = {version = "0.3.0", optional = true }
 algebra = { git = "https://github.com/scipr-lab/zexe", features = ["bls12_377", "edwards_sw6"], optional = true }
 bls-crypto = { git = "https://github.com/celo-org/bls-zexe", optional = true }
 thiserror = "1.0.15"
+bincode = "1.2.1"
 
 [features]
 default = ["bls12_381", "bls12_377"]

--- a/crates/threshold-bls/src/lib.rs
+++ b/crates/threshold-bls/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryInto, fmt::Debug};
+use serde::{Deserialize, Serialize};
 
 pub mod curve;
 pub mod ecies;
@@ -7,16 +7,12 @@ pub mod poly;
 pub mod sig;
 pub use group::*;
 
-use serde::{Deserialize, Serialize};
-use thiserror::Error;
-
 pub type Index = poly::Idx;
 
 pub type DistPublic<C> = poly::PublicPoly<C>;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(bound = "S: Serialize + serde::de::DeserializeOwned")]
-pub struct Share<S: Scalar> {
+pub struct Share<S> {
     pub index: Index,
     pub private: S,
 }
@@ -24,74 +20,5 @@ pub struct Share<S: Scalar> {
 impl<S: Scalar> Share<S> {
     pub fn new(index: Index, private: S) -> Self {
         Self { index, private }
-    }
-}
-
-#[derive(Debug, Error)]
-pub enum ShareError<E: Encodable + Debug> {
-    #[error("could not deserialize index: {0}")]
-    IndexError(#[from] std::array::TryFromSliceError),
-    #[error("could not deserialize scalar: {0}")]
-    EncodableError(E::Error),
-}
-
-impl<S> Encodable for Share<S>
-where
-    S: Scalar,
-{
-    type Error = ShareError<S>;
-
-    fn marshal_len() -> usize {
-        <S as Encodable>::marshal_len() + std::mem::size_of::<Index>()
-    }
-
-    fn marshal(&self) -> Vec<u8> {
-        let mut bytes = self.index.to_le_bytes().to_vec();
-        let pk_bytes = self.private.marshal();
-        bytes.extend_from_slice(&pk_bytes);
-        bytes
-    }
-
-    fn unmarshal(&mut self, data: &[u8]) -> Result<(), ShareError<S>> {
-        let (int_bytes, rest) = data.split_at(std::mem::size_of::<Index>());
-        let index = u32::from_le_bytes(int_bytes.try_into()?);
-
-        self.index = index;
-        self.private
-            .unmarshal(rest)
-            // We cannot implement `From` for ScalarError because it is generic
-            // and results in `conflicting From<T> for T` implementations
-            .map_err(ShareError::EncodableError)?;
-
-        Ok(())
-    }
-}
-
-#[cfg(test)]
-#[cfg(feature = "bls12_377")]
-mod tests {
-    use super::*;
-    use group::Encodable;
-
-    use curve::zexe::Scalar;
-
-    #[test]
-    fn share_serialization() {
-        let rng = &mut rand::thread_rng();
-        for _ in 0..100 {
-            let mut pk = Scalar::new();
-            pk.pick(rng);
-
-            let share = Share {
-                index: rand::random(),
-                private: pk,
-            };
-
-            let ser = share.marshal();
-            let mut de = Share::new(0, Scalar::new());
-            de.unmarshal(&ser).unwrap();
-
-            assert_eq!(share, de);
-        }
     }
 }

--- a/crates/threshold-bls/src/poly.rs
+++ b/crates/threshold-bls/src/poly.rs
@@ -1,9 +1,8 @@
 use crate::group::{Curve, Element, Point, Scalar};
 use rand_core::RngCore;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::fmt;
-use std::marker::PhantomData;
+use std::{collections::HashMap, fmt, marker::PhantomData};
+use thiserror::Error;
 
 // TODO can't we have trait bounds on type aliases ?
 pub type PrivatePoly<C> = Poly<<C as Curve>::Scalar, <C as Curve>::Scalar>;
@@ -12,15 +11,12 @@ pub type PublicPoly<C> = Poly<<C as Curve>::Scalar, <C as Curve>::Point>;
 pub type Idx = u32;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Eval<A: Clone> {
+pub struct Eval<A> {
     pub value: A,
     pub index: Idx,
 }
 
-impl<A> fmt::Display for Eval<A>
-where
-    A: Element,
-{
+impl<A: fmt::Display> fmt::Display for Eval<A> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{{ idx: {}, value: {} }}", self.index, self.value)
     }
@@ -38,8 +34,6 @@ pub struct Poly<Var: Scalar, Coeff: Element<Var>> {
     c: Vec<Coeff>,
     phantom: PhantomData<Var>,
 }
-
-use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum PolyError {

--- a/crates/threshold-bls/src/poly.rs
+++ b/crates/threshold-bls/src/poly.rs
@@ -1,9 +1,7 @@
 use crate::group::{Curve, Element, Point, Scalar};
-use crate::Encodable;
 use rand_core::RngCore;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::convert::TryInto;
 use std::fmt;
 use std::marker::PhantomData;
 
@@ -35,6 +33,7 @@ where
 //  constraint but not in the struct directly.-> phantomdata ?
 //  TODO: make it implement Element trait ;) ?
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(bound = "Var: Serialize + serde::de::DeserializeOwned")]
 pub struct Poly<Var: Scalar, Coeff: Element<Var>> {
     c: Vec<Coeff>,
     phantom: PhantomData<Var>,
@@ -43,63 +42,15 @@ pub struct Poly<Var: Scalar, Coeff: Element<Var>> {
 use thiserror::Error;
 
 #[derive(Debug, Error)]
-pub enum PolyError<E: Encodable + std::fmt::Debug> {
-    #[error("could not deserialize polynomial length: {0}")]
-    LengthError(#[from] std::array::TryFromSliceError),
-
-    #[error("could not deserialize polynomial coefficient: {0}")]
-    CoefficientError(E::Error),
-
+pub enum PolyError {
     #[error("Invalid recovery: only has {0}/{1} shares")]
     InvalidRecovery(usize, usize),
-}
-
-impl<Var, Coeff> Encodable for Poly<Var, Coeff>
-where
-    Var: Scalar,
-    Coeff: Element<Var> + Encodable,
-{
-    type Error = PolyError<Coeff>;
-
-    // This cannot be known as the Poly is a variable length data structure.
-    fn marshal_len() -> usize {
-        unreachable!()
-    }
-
-    fn marshal(&self) -> Vec<u8> {
-        let mut bytes = self.c.len().to_le_bytes().to_vec();
-        for coeff in &self.c {
-            let coeff_bytes = coeff.marshal();
-            bytes.extend_from_slice(&coeff_bytes);
-        }
-        bytes
-    }
-
-    fn unmarshal(&mut self, data: &[u8]) -> Result<(), Self::Error> {
-        let (int_bytes, rest) = data.split_at(std::mem::size_of::<usize>());
-        let num_coeffs = usize::from_le_bytes(int_bytes.try_into()?);
-
-        let mut coeffs = Vec::new();
-
-        let size = Coeff::marshal_len();
-        for i in 0..num_coeffs {
-            let mut coeff = Coeff::new();
-            coeff
-                .unmarshal(&rest[i * size..(i + 1) * size])
-                .map_err(PolyError::CoefficientError)?;
-            coeffs.push(coeff);
-        }
-
-        self.c = coeffs;
-
-        Ok(())
-    }
 }
 
 impl<X, C> Poly<X, C>
 where
     X: Scalar,
-    C: Element<X> + Encodable,
+    C: Element<X>,
 {
     /// Returns a new polynomial of the given degree where each coefficients is
     /// sampled at random from the given RNG.
@@ -157,7 +108,7 @@ where
         zipped.for_each(|(a, b)| a.add(&b));
     }
 
-    pub fn recover(t: usize, mut shares: Vec<Eval<C>>) -> Result<C, PolyError<C>> {
+    pub fn recover(t: usize, mut shares: Vec<Eval<C>>) -> Result<C, PolyError> {
         if shares.len() < t {
             return Err(PolyError::InvalidRecovery(shares.len(), t));
         }
@@ -199,7 +150,7 @@ where
         Ok(acc)
     }
 
-    pub fn full_recover(t: usize, mut shares: Vec<Eval<C>>) -> Result<Self, PolyError<C>> {
+    pub fn full_recover(t: usize, mut shares: Vec<Eval<C>>) -> Result<Self, PolyError> {
         if shares.len() < t {
             return Err(PolyError::InvalidRecovery(shares.len(), t));
         }
@@ -354,7 +305,7 @@ impl<X: Scalar> Poly<X, X> {
 impl<X, Y> fmt::Display for Poly<X, Y>
 where
     X: Scalar,
-    Y: Element<X> + Encodable,
+    Y: Element<X>,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let s = self
@@ -387,10 +338,9 @@ pub mod tests {
     fn serialization() {
         let p = Poly::<Sc, Sc>::new(10);
 
-        let ser = p.marshal();
+        let ser = bincode::serialize(&p).unwrap();
 
-        let mut de = Poly::<Sc, Sc>::new(0);
-        de.unmarshal(&ser).unwrap();
+        let de: Poly<Sc, Sc> = bincode::deserialize(&ser).unwrap();
 
         assert_eq!(p, de);
     }

--- a/crates/threshold-bls/src/poly.rs
+++ b/crates/threshold-bls/src/poly.rs
@@ -11,7 +11,7 @@ pub type PublicPoly<C> = Poly<<C as Curve>::Scalar, <C as Curve>::Point>;
 
 pub type Idx = u32;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Eval<A: Clone> {
     pub value: A,
     pub index: Idx,

--- a/crates/threshold-bls/src/sig/sig.rs
+++ b/crates/threshold-bls/src/sig/sig.rs
@@ -1,7 +1,8 @@
-use crate::group::{Element, Encodable, Point, Scalar};
+use crate::group::{Element, Point, Scalar};
 use crate::poly::Poly;
 use crate::Share;
 use rand_core::RngCore;
+use serde::{de::DeserializeOwned, Serialize};
 use std::{error::Error, fmt::Debug};
 
 /// The `Scheme` trait contains the basic information of the groups over
@@ -15,9 +16,9 @@ pub trait Scheme: Debug {
     type Private: Scalar;
     /// `Public` represents the group over which the public keys are
     /// represented.
-    type Public: Point<Self::Private> + Encodable;
+    type Public: Point<Self::Private> + Serialize + DeserializeOwned;
     /// `Signature` represents the group over which the signatures are reresented.
-    type Signature: Point<Self::Private> + Encodable;
+    type Signature: Point<Self::Private> + Serialize + DeserializeOwned;
 
     /// Returns a new fresh keypair usable by the scheme.
     fn keypair<R: RngCore>(rng: &mut R) -> (Self::Private, Self::Public) {
@@ -37,7 +38,7 @@ pub trait Scheme: Debug {
 ///  # #[cfg(feature = "bls12_381")]
 ///  # {
 ///  use rand::prelude::*;
-///  use threshold_bls::{sig::{SignatureScheme,Scheme}, Element, Encodable, Point};
+///  use threshold_bls::{sig::{SignatureScheme,Scheme}, Element, Point};
 ///  use threshold_bls::curve::bls12381::PairingCurve as PC;
 ///  // import BLS signatures with public keys over G2
 ///  use threshold_bls::sig::bls::G2Scheme;
@@ -76,7 +77,7 @@ pub trait SignatureSchemeExt: SignatureScheme {
 /// not to be used alone but in combination with a signature scheme or a
 /// threshold scheme.
 pub trait Blinder {
-    type Token: Encodable;
+    type Token: Serialize + DeserializeOwned;
     type Error: Error;
 
     fn blind<R: RngCore>(msg: &[u8], rng: &mut R) -> (Self::Token, Vec<u8>);


### PR DESCRIPTION
The trait `Encodable` is removed in favor of the `serde` implementations. The custom index related methods are also removed, and the `Eval` struct is reused for partial signatures. 

Tradeoffs:
- The lengths of datatypes are hard-coded in FFI
- Due to having a generalized serializer, the partial signature is now 8 bytes bigger to account for the vector length