### PR TITLE
Simplify Polynomial type definition

### DIFF
--- a/crates/dkg-cli/src/coordinator/actions.rs
+++ b/crates/dkg-cli/src/coordinator/actions.rs
@@ -2,11 +2,7 @@ use super::opts::{CombineOpts, SetupOpts};
 use crate::CLIResult;
 use dkg_core::node::NodeError;
 use dkg_core::primitives::{Group, Node};
-use threshold_bls::{
-    group::{Curve, Point},
-    sig::Scheme,
-    Index,
-};
+use threshold_bls::{group::Curve, sig::Scheme, Index};
 
 use glob::glob;
 use serde::{de::DeserializeOwned, Serialize};
@@ -18,8 +14,6 @@ where
     C: Curve,
     // We need to bind the Curve's Point and Scalars to the Scheme
     S: Scheme<Public = <C as Curve>::Point, Private = <C as Curve>::Scalar>,
-    <C as Curve>::Point: Point<S::Private>,
-    <S as Scheme>::Signature: Point<<C as Curve>::Scalar>,
 {
     let mut nodes = Vec::new();
 

--- a/crates/dkg-cli/src/user/actions.rs
+++ b/crates/dkg-cli/src/user/actions.rs
@@ -10,10 +10,7 @@ use dkg_core::{
     },
 };
 
-use threshold_bls::{
-    group::{Curve, Point},
-    sig::Scheme,
-};
+use threshold_bls::{group::Curve, sig::Scheme};
 
 pub fn keygen<S, R>(opts: NewOpts, mut rng: R) -> CLIResult<()>
 where
@@ -38,7 +35,6 @@ where
     C: Curve,
     // We need to bind the Curve's Point and Scalars to the Scheme
     S: Scheme<Public = <C as Curve>::Point, Private = <C as Curve>::Scalar>,
-    <S as Scheme>::Signature: Point<<C as Curve>::Scalar>,
 {
     let private_key_file = File::open(opts.private_key)?;
     let pk: S::Private = bincode::deserialize_from(private_key_file)?;

--- a/crates/dkg-core/src/node.rs
+++ b/crates/dkg-core/src/node.rs
@@ -143,7 +143,6 @@ mod tests {
     use threshold_bls::{
         curve::bls12381::{self, PairingCurve as BLS12_381},
         curve::zexe::{self as bls12_377, PairingCurve as BLS12_377},
-        group::Point,
         sig::{
             bls::{G1Scheme, G2Scheme},
             BlindThresholdScheme, Scheme,
@@ -167,8 +166,6 @@ mod tests {
         // We need to bind the Curve's Point and Scalars to the Scheme
         S: Scheme<Public = <C as Curve>::Point, Private = <C as Curve>::Scalar>
             + BlindThresholdScheme,
-        <C as Curve>::Point: Point<S::Private>,
-        <S as Scheme>::Signature: Point<<C as Curve>::Scalar>,
     {
         let msg = rand::random::<[u8; 32]>().to_vec();
 
@@ -202,8 +199,6 @@ mod tests {
         C: Curve,
         // We need to bind the Curve's Point and Scalars to the Scheme
         S: Scheme<Public = <C as Curve>::Point, Private = <C as Curve>::Scalar>,
-        <C as Curve>::Point: Point<S::Private>,
-        <S as Scheme>::Signature: Point<<C as Curve>::Scalar>,
     {
         let rng = &mut rand::thread_rng();
 
@@ -360,8 +355,6 @@ mod tests {
         C: Curve,
         // We need to bind the Curve's Point and Scalars to the Scheme
         S: Scheme<Public = <C as Curve>::Point, Private = <C as Curve>::Scalar>,
-        <C as Curve>::Point: Point<S::Private>,
-        <S as Scheme>::Signature: Point<<C as Curve>::Scalar>,
     {
         // generate a keypair per participant
         let keypairs = (0..n).map(|_| S::keypair(rng)).collect::<Vec<_>>();

--- a/crates/dkg-core/src/primitives.rs
+++ b/crates/dkg-core/src/primitives.rs
@@ -185,8 +185,8 @@ struct DKGInfo<C: Curve> {
     private_key: C::Scalar,
     index: ID,
     group: Group<C>,
-    secret: Poly<C::Scalar, C::Scalar>,
-    public: Poly<C::Scalar, C::Point>,
+    secret: Poly<C::Scalar>,
+    public: Poly<C::Point>,
 }
 
 impl<C> DKGInfo<C>

--- a/crates/threshold-bls-ffi/src/ffi.rs
+++ b/crates/threshold-bls-ffi/src/ffi.rs
@@ -208,7 +208,7 @@ pub extern "C" fn partial_sign_blinded_message(
 pub extern "C" fn partial_verify(
     // TODO: The polynomial does not have a constant length type. Is it safe to not
     // pass any length parameter?
-    polynomial: *const Poly<PrivateKey, PublicKey>,
+    polynomial: *const Poly<PublicKey>,
     blinded_message: *const Buffer,
     sig: *const Buffer,
 ) -> bool {
@@ -228,7 +228,7 @@ pub extern "C" fn partial_verify(
 pub extern "C" fn partial_verify_blind_signature(
     // TODO: The polynomial does not have a constant length type. Is it safe to not
     // pass any length parameter?
-    polynomial: *const Poly<PrivateKey, PublicKey>,
+    polynomial: *const Poly<PublicKey>,
     blinded_message: *const Buffer,
     sig: *const Buffer,
 ) -> bool {
@@ -394,7 +394,7 @@ pub extern "C" fn destroy_sig(signature: *mut Signature) {
 #[no_mangle]
 pub extern "C" fn threshold_keygen(n: usize, t: usize, seed: &[u8], keys: *mut *mut Keys) {
     let mut rng = get_rng(seed);
-    let private = Poly::<PrivateKey, PrivateKey>::new_from(t - 1, &mut rng);
+    let private = Poly::<PrivateKey>::new_from(t - 1, &mut rng);
     let shares = (0..n)
         .map(|i| private.eval(i as Index))
         .map(|e| Share {
@@ -448,8 +448,8 @@ pub extern "C" fn num_shares(keys: *const Keys) -> usize {
 
 /// Gets a pointer to the polynomial corresponding to the provided `Keys` pointer
 #[no_mangle]
-pub extern "C" fn polynomial_ptr(keys: *const Keys) -> *const Poly<PrivateKey, PublicKey> {
-    &unsafe { &*keys }.polynomial as *const Poly<PrivateKey, PublicKey>
+pub extern "C" fn polynomial_ptr(keys: *const Keys) -> *const Poly<PublicKey> {
+    &unsafe { &*keys }.polynomial as *const Poly<PublicKey>
 }
 
 /// Gets a pointer to the threshold public key corresponding to the provided `Keys` pointer
@@ -474,7 +474,7 @@ pub extern "C" fn private_key_ptr(keypair: *const Keypair) -> *const PrivateKey 
 #[derive(Debug, Clone)]
 pub struct Keys {
     shares: Vec<Share<PrivateKey>>,
-    polynomial: Poly<PrivateKey, PublicKey>,
+    polynomial: Poly<PublicKey>,
     threshold_public_key: PublicKey,
     pub t: usize,
     pub n: usize,

--- a/crates/threshold-bls-ffi/src/wasm.rs
+++ b/crates/threshold-bls-ffi/src/wasm.rs
@@ -151,7 +151,7 @@ pub fn partial_sign_blinded_message(share_buf: &[u8], message: &[u8]) -> Result<
 ///
 /// - If verification fails
 pub fn partial_verify(polynomial_buf: &[u8], blinded_message: &[u8], sig: &[u8]) -> Result<()> {
-    let polynomial: Poly<PrivateKey, PublicKey> = bincode::deserialize(&polynomial_buf)
+    let polynomial: Poly<PublicKey> = bincode::deserialize(&polynomial_buf)
         .map_err(|err| JsValue::from_str(&format!("could not deserialize polynomial {}", err)))?;
 
     SigScheme::partial_verify(&polynomial, blinded_message, sig)
@@ -170,7 +170,7 @@ pub fn partial_verify_blind_signature(
     blinded_message: &[u8],
     sig: &[u8],
 ) -> Result<()> {
-    let polynomial: Poly<PrivateKey, PublicKey> = bincode::deserialize(&polynomial_buf)
+    let polynomial: Poly<PublicKey> = bincode::deserialize(&polynomial_buf)
         .map_err(|err| JsValue::from_str(&format!("could not deserialize polynomial {}", err)))?;
 
     SigScheme::partial_verify_without_hashing(&polynomial, blinded_message, sig)
@@ -227,7 +227,7 @@ pub fn combine(threshold: usize, signatures: Vec<u8>) -> Result<Vec<u8>> {
 /// The seed MUST be at least 32 bytes long
 pub fn threshold_keygen(n: usize, t: usize, seed: &[u8]) -> Keys {
     let mut rng = get_rng(seed);
-    let private = Poly::<PrivateKey, PrivateKey>::new_from(t - 1, &mut rng);
+    let private = Poly::<PrivateKey>::new_from(t - 1, &mut rng);
     let shares = (0..n)
         .map(|i| private.eval(i as Index))
         .map(|e| Share {
@@ -308,7 +308,7 @@ pub fn keygen(seed: Vec<u8>) -> Keypair {
 #[wasm_bindgen]
 pub struct Keys {
     shares: Vec<Share<PrivateKey>>,
-    polynomial: Poly<PrivateKey, PublicKey>,
+    polynomial: Poly<PublicKey>,
     pub t: usize,
     pub n: usize,
 }

--- a/crates/threshold-bls/src/curve/bls12381.rs
+++ b/crates/threshold-bls/src/curve/bls12381.rs
@@ -25,7 +25,9 @@ pub enum BellmanError {
     GroupDecodingError(#[from] groupy::GroupDecodingError),
 }
 
-impl Element<Scalar> for Scalar {
+impl Element for Scalar {
+    type RHS = Fr;
+
     fn new() -> Self {
         ff::Field::zero()
     }
@@ -63,7 +65,9 @@ impl Sc for Scalar {
     }
 }
 /// G1 points can be multiplied by Fr elements
-impl Element<Scalar> for G1 {
+impl Element for G1 {
+    type RHS = Scalar;
+
     fn new() -> Self {
         groupy::CurveProjective::zero()
     }
@@ -85,7 +89,9 @@ impl Element<Scalar> for G1 {
     }
 }
 
-impl Element<Scalar> for G2 {
+impl Element for G2 {
+    type RHS = Scalar;
+
     fn new() -> Self {
         groupy::CurveProjective::zero()
     }
@@ -108,7 +114,7 @@ impl Element<Scalar> for G2 {
 }
 
 /// Implementation of Point using G1 from BLS12-381
-impl Point<Fr> for G1 {
+impl Point for G1 {
     type Error = ();
 
     fn map(&mut self, data: &[u8]) -> Result<(), ()> {
@@ -118,7 +124,7 @@ impl Point<Fr> for G1 {
 }
 
 /// Implementation of Point using G2 from BLS12-381
-impl Point<Fr> for G2 {
+impl Point for G2 {
     type Error = ();
 
     fn map(&mut self, data: &[u8]) -> Result<(), ()> {
@@ -128,6 +134,8 @@ impl Point<Fr> for G2 {
 }
 
 impl Element for GT {
+    type RHS = GT;
+
     fn new() -> Self {
         ff::Field::zero()
     }
@@ -179,7 +187,7 @@ mod tests {
     assert_impl_all!(Scalar: Serialize, DeserializeOwned, Clone);
 
     // test if the element trait is usable
-    fn add_two<T: Element>(e1: &mut T, e2: &T) {
+    fn add_two<T: Element<RHS = T>>(e1: &mut T, e2: &T) {
         e1.add(e2);
         e1.mul(e2);
     }

--- a/crates/threshold-bls/src/curve/zexe.rs
+++ b/crates/threshold-bls/src/curve/zexe.rs
@@ -67,7 +67,9 @@ pub struct GT(
     <zexe::Bls12_377 as PairingEngine>::Fqk,
 );
 
-impl Element<Scalar> for Scalar {
+impl Element for Scalar {
+    type RHS = Scalar;
+
     fn new() -> Self {
         Self(Zero::zero())
     }
@@ -114,7 +116,9 @@ impl fmt::Display for Scalar {
 }
 
 /// G1 points can be multiplied by Fr elements
-impl Element<Scalar> for G1 {
+impl Element for G1 {
+    type RHS = Scalar;
+
     fn new() -> Self {
         Self(Zero::zero())
     }
@@ -137,7 +141,7 @@ impl Element<Scalar> for G1 {
 }
 
 /// Implementation of Point using G1 from BLS12-377
-impl Point<Scalar> for G1 {
+impl Point for G1 {
     type Error = ZexeError;
 
     fn map(&mut self, data: &[u8]) -> Result<(), ZexeError> {
@@ -158,7 +162,9 @@ impl fmt::Display for G1 {
 }
 
 /// G1 points can be multiplied by Fr elements
-impl Element<Scalar> for G2 {
+impl Element for G2 {
+    type RHS = Scalar;
+
     fn new() -> Self {
         Self(Zero::zero())
     }
@@ -181,7 +187,7 @@ impl Element<Scalar> for G2 {
 }
 
 /// Implementation of Point using G2 from BLS12-377
-impl Point<Scalar> for G2 {
+impl Point for G2 {
     type Error = ZexeError;
 
     fn map(&mut self, data: &[u8]) -> Result<(), ZexeError> {
@@ -200,7 +206,9 @@ impl fmt::Display for G2 {
     }
 }
 
-impl Element<GT> for GT {
+impl Element for GT {
+    type RHS = GT;
+
     fn new() -> Self {
         Self(Zero::zero())
     }
@@ -383,7 +391,7 @@ mod tests {
         serialize_group_test::<G2>(96);
     }
 
-    fn serialize_group_test<E: Element<Scalar>>(size: usize) {
+    fn serialize_group_test<E: Element>(size: usize) {
         let rng = &mut rand::thread_rng();
         let sig = E::rand(rng);
         let ser = bincode::serialize(&sig).unwrap();

--- a/crates/threshold-bls/src/group.rs
+++ b/crates/threshold-bls/src/group.rs
@@ -9,9 +9,9 @@ use std::marker::PhantomData;
 /// which is also equipped with a multiplication transformation.
 /// Two implementations are for Scalar which forms a ring so RHS is the same
 /// and Point which can be multiplied by a scalar of its prime field.
-pub trait Element<RHS = Self>:
-    Clone + Display + Debug + Eq + Serialize + for<'a> Deserialize<'a>
-{
+pub trait Element: Clone + Display + Debug + Eq + Serialize + for<'a> Deserialize<'a> {
+    type RHS;
+
     /// new MUST return the zero element of the group.
     fn new() -> Self;
 
@@ -19,7 +19,7 @@ pub trait Element<RHS = Self>:
 
     fn add(&mut self, s2: &Self);
 
-    fn mul(&mut self, mul: &RHS);
+    fn mul(&mut self, mul: &Self::RHS);
 
     fn rand<R: RngCore>(rng: &mut R) -> Self;
 
@@ -39,19 +39,17 @@ pub trait Scalar: Element {
 }
 
 /// Basic point functionality that can be multiplied by a scalar
-pub trait Point<A: Scalar>: Element<A> {
+pub trait Point: Element {
     type Error: Debug;
 
-    fn map(&mut self, data: &[u8]) -> Result<(), <Self as Point<A>>::Error>;
+    fn map(&mut self, data: &[u8]) -> Result<(), <Self as Point>::Error>;
 }
-
-//type PPoint = Point<A: Scalar>;
 
 /// A group holds functionalities to create scalar and points related; it is
 /// similar to the Engine definition, just much more simpler.
 pub trait Curve: Clone + Debug {
-    type Scalar: Scalar;
-    type Point: Point<Self::Scalar>;
+    type Scalar: Scalar<RHS = Self::Scalar>;
+    type Point: Point<RHS = Self::Scalar>;
 
     /// scalar returns the identity element of the field.
     fn scalar() -> Self::Scalar {
@@ -65,24 +63,24 @@ pub trait Curve: Clone + Debug {
 }
 
 pub trait PairingCurve: Debug {
-    type Scalar: Scalar;
-    type G1: Point<Self::Scalar>;
-    type G2: Point<Self::Scalar>;
+    type Scalar: Scalar<RHS = Self::Scalar>;
+    type G1: Point<RHS = Self::Scalar>;
+    type G2: Point<RHS = Self::Scalar>;
     type GT: Element;
 
     fn pair(a: &Self::G1, b: &Self::G2) -> Self::GT;
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct CurveFrom<S: Scalar, P: Point<S>> {
+pub struct CurveFrom<S: Scalar, P: Point> {
     m: PhantomData<S>,
     mm: PhantomData<P>,
 }
 
 impl<S, P> Curve for CurveFrom<S, P>
 where
-    S: Scalar,
-    P: Point<S>,
+    S: Scalar<RHS = S>,
+    P: Point<RHS = S>,
 {
     type Scalar = S;
     type Point = P;

--- a/crates/threshold-bls/src/sig/sig.rs
+++ b/crates/threshold-bls/src/sig/sig.rs
@@ -13,12 +13,12 @@ use std::{error::Error, fmt::Debug};
 /// well for threshold based signature scheme.
 pub trait Scheme: Debug {
     /// `Private` represents the field over which private keys are represented.
-    type Private: Scalar;
+    type Private: Scalar<RHS = Self::Private>;
     /// `Public` represents the group over which the public keys are
     /// represented.
-    type Public: Point<Self::Private> + Serialize + DeserializeOwned;
+    type Public: Point<RHS = Self::Private> + Serialize + DeserializeOwned;
     /// `Signature` represents the group over which the signatures are reresented.
-    type Signature: Point<Self::Private> + Serialize + DeserializeOwned;
+    type Signature: Point<RHS = Self::Private> + Serialize + DeserializeOwned;
 
     /// Returns a new fresh keypair usable by the scheme.
     fn keypair<R: RngCore>(rng: &mut R) -> (Self::Private, Self::Public) {
@@ -105,7 +105,7 @@ pub trait ThresholdScheme: Scheme {
     fn partial_sign(private: &Share<Self::Private>, msg: &[u8]) -> Result<Partial, Self::Error>;
 
     fn partial_verify(
-        public: &Poly<Self::Private, Self::Public>,
+        public: &Poly<Self::Public>,
         msg: &[u8],
         partial: &[u8],
     ) -> Result<(), Self::Error>;
@@ -125,7 +125,7 @@ pub trait ThresholdSchemeExt: ThresholdScheme {
     ) -> Result<Partial, Self::Error>;
 
     fn partial_verify_without_hashing(
-        public: &Poly<Self::Private, Self::Public>,
+        public: &Poly<Self::Public>,
         msg: &[u8],
         partial: &[u8],
     ) -> Result<(), Self::Error>;

--- a/crates/threshold-bls/src/sig/tblind.rs
+++ b/crates/threshold-bls/src/sig/tblind.rs
@@ -55,8 +55,8 @@ mod tests {
     fn shares<B: BlindThresholdScheme>(
         n: usize,
         t: usize,
-    ) -> (Vec<Share<B::Private>>, Poly<B::Private, B::Public>) {
-        let private = Poly::<B::Private, B::Private>::new(t - 1);
+    ) -> (Vec<Share<B::Private>>, Poly<B::Public>) {
+        let private = Poly::<B::Private>::new(t - 1);
         let shares = (0..n)
             .map(|i| private.eval(i as Index))
             .map(|e| Share {

--- a/crates/threshold-bls/src/sig/tbls.rs
+++ b/crates/threshold-bls/src/sig/tbls.rs
@@ -38,7 +38,7 @@ impl<I: SignatureScheme> ThresholdScheme for I {
     }
 
     fn partial_verify(
-        public: &Poly<Self::Private, Self::Public>,
+        public: &Poly<Self::Public>,
         msg: &[u8],
         partial: &[u8],
     ) -> Result<(), <Self as ThresholdScheme>::Error> {
@@ -72,9 +72,8 @@ impl<I: SignatureScheme> ThresholdScheme for I {
             })
             .collect::<Result<_, <Self as ThresholdScheme>::Error>>()?;
 
-        let recovered_sig =
-            Poly::<Self::Private, Self::Signature>::recover(threshold, valid_partials)
-                .map_err(ThresholdError::PolyError)?;
+        let recovered_sig = Poly::<Self::Signature>::recover(threshold, valid_partials)
+            .map_err(ThresholdError::PolyError)?;
         Ok(bincode::serialize(&recovered_sig).expect("could not serialize"))
     }
 
@@ -102,7 +101,7 @@ impl<I: SignatureSchemeExt> ThresholdSchemeExt for I {
     }
 
     fn partial_verify_without_hashing(
-        public: &Poly<Self::Private, Self::Public>,
+        public: &Poly<Self::Public>,
         msg: &[u8],
         partial: &[u8],
     ) -> Result<(), <Self as ThresholdScheme>::Error> {
@@ -132,14 +131,11 @@ mod tests {
         usize,
     ) -> (
         Vec<Share<<T as Scheme>::Private>>,
-        Poly<<T as Scheme>::Private, <T as Scheme>::Public>,
+        Poly<<T as Scheme>::Public>,
     );
 
-    fn shares<T: ThresholdScheme>(
-        n: usize,
-        t: usize,
-    ) -> (Vec<Share<T::Private>>, Poly<T::Private, T::Public>) {
-        let private = Poly::<T::Private, T::Private>::new(t - 1);
+    fn shares<T: ThresholdScheme>(n: usize, t: usize) -> (Vec<Share<T::Private>>, Poly<T::Public>) {
+        let private = Poly::<T::Private>::new(t - 1);
         let shares = (0..n)
             .map(|i| private.eval(i as Index))
             .map(|e| Share {


### PR DESCRIPTION
By making the `RHS` parameter of the `Element` trait an associated type, we're able to get rid of the `PhantomData` and drastically simplify the polynomial type definition.