### PR TITLE
Split DKG Core in modules

### DIFF
--- a/crates/dkg-cli/src/bin/coordinator.rs
+++ b/crates/dkg-cli/src/bin/coordinator.rs
@@ -3,7 +3,7 @@ use dkg_cli::coordinator::{
     opts::{Command, Opts},
 };
 
-use dkg_core::primitives::{BundledJustification, BundledResponses, BundledShares};
+use dkg_core::primitives::states::{BundledJustification, BundledResponses, BundledShares};
 
 use gumdrop::Options;
 use std::process;

--- a/crates/dkg-cli/src/coordinator/actions.rs
+++ b/crates/dkg-cli/src/coordinator/actions.rs
@@ -1,7 +1,10 @@
 use super::opts::{CombineOpts, SetupOpts};
 use crate::CLIResult;
-use dkg_core::node::NodeError;
-use dkg_core::primitives::{Group, Node};
+
+use dkg_core::{
+    node::NodeError,
+    primitives::group::{Group, Node},
+};
 use threshold_bls::{group::Curve, sig::Scheme, Index};
 
 use glob::glob;

--- a/crates/dkg-cli/src/user/actions.rs
+++ b/crates/dkg-cli/src/user/actions.rs
@@ -6,7 +6,8 @@ use std::fs::File;
 use dkg_core::{
     node::{DKGPhase, Phase0, Phase1, Phase2, Phase2Result},
     primitives::{
-        BundledJustification, BundledResponses, BundledShares, DKGWaitingJustification, Group,
+        group::Group,
+        states::{BundledJustification, BundledResponses, BundledShares, DKGWaitingJustification},
     },
 };
 

--- a/crates/dkg-core/src/board.rs
+++ b/crates/dkg-core/src/board.rs
@@ -2,7 +2,7 @@
 ///
 /// A board is where DKG participants publish their data for the corresponding DKG
 /// phase.
-use super::primitives::{BundledJustification, BundledResponses, BundledShares};
+use super::primitives::states::{BundledJustification, BundledResponses, BundledShares};
 use bincode::serialize_into;
 use std::io::Write;
 use threshold_bls::group::Curve;

--- a/crates/dkg-core/src/node.rs
+++ b/crates/dkg-core/src/node.rs
@@ -1,8 +1,12 @@
 use super::{
     board::BoardPublisher,
     primitives::{
-        BundledResponses, BundledShares, DKGError, DKGOutput, DKGWaitingJustification,
-        DKGWaitingResponse, DKGWaitingShare, Group, DKG,
+        group::Group,
+        states::{
+            BundledResponses, BundledShares, DKGOutput, DKGWaitingJustification,
+            DKGWaitingResponse, DKGWaitingShare, DKG,
+        },
+        DKGError,
     },
 };
 
@@ -133,10 +137,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        primitives::{Group, Node},
-        test_helpers::InMemoryBoard,
-    };
+    use crate::{primitives::group::Node, test_helpers::InMemoryBoard};
 
     use threshold_bls::{
         curve::bls12381::{self, PairingCurve as BLS12_381},

--- a/crates/dkg-core/src/primitives/group.rs
+++ b/crates/dkg-core/src/primitives/group.rs
@@ -1,0 +1,133 @@
+use super::{default_threshold, minimum_threshold, DKGError, DKGResult};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use std::fmt;
+use threshold_bls::{group::Curve, poly::Idx};
+
+/// Node is a participant in the DKG protocol. In a DKG protocol, each
+/// participant must be identified both by an index and a public key. At the end
+/// of the protocol, if sucessful, the index is used to verify the validity of
+/// the share this node holds.
+#[derive(Clone, Serialize, Deserialize, PartialEq)]
+pub struct Node<C: Curve>(Idx, C::Point);
+
+impl<C> Node<C>
+where
+    C: Curve,
+{
+    pub fn new(index: Idx, public: C::Point) -> Self {
+        Self(index, public)
+    }
+}
+
+impl<C> fmt::Debug for Node<C>
+where
+    C: Curve,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Node{{{} -> {:?} }}", self.0, self.1)
+    }
+}
+
+impl<C> Node<C>
+where
+    C: Curve,
+{
+    pub fn id(&self) -> Idx {
+        self.0
+    }
+    pub fn key(&self) -> &C::Point {
+        &self.1
+    }
+}
+
+/// A Group is a collection of Nodes with an associated threshold. A DKG scheme
+/// takes in a group at the beginning of the protocol and outputs a potentially
+/// new group that contains members that succesfully ran the protocol. When
+/// creating a new group using the `from()` or `from_list()`method, the module
+/// sets the threshold to the output of `default_threshold()`.
+#[derive(Clone, Serialize, Deserialize, PartialEq)]
+#[serde(bound = "C::Scalar: DeserializeOwned")]
+pub struct Group<C: Curve> {
+    pub nodes: Vec<Node<C>>,
+    pub threshold: usize,
+}
+
+impl<C> Group<C>
+where
+    C: Curve,
+{
+    /// Converts a vector of nodes to a group with the default threshold (51%)
+    pub fn from_list(nodes: Vec<Node<C>>) -> Group<C> {
+        let l = nodes.len();
+        Self {
+            nodes,
+            threshold: default_threshold(l),
+        }
+    }
+
+    /// Creates a new group from the provided vector of nodes and threshold.
+    ///
+    /// Valid thresholds are `>= 51% * nodes.len()` and `<= 100% * nodes.len()`
+    pub fn new(nodes: Vec<Node<C>>, threshold: usize) -> DKGResult<Group<C>> {
+        let minimum = minimum_threshold(nodes.len());
+        let maximum = nodes.len();
+
+        // reject invalid thresholds
+        if threshold < minimum || threshold > maximum {
+            return Err(DKGError::InvalidThreshold(threshold, minimum, maximum));
+        }
+
+        Ok(Self { nodes, threshold })
+    }
+
+    /// Returns the number of nodes in the group
+    pub fn len(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// Checks if the group is empty
+    pub fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+
+    /// Gets the index of the node corresponding to the provided public key
+    pub fn index(&self, public: &C::Point) -> Option<Idx> {
+        self.nodes.iter().find(|n| &n.1 == public).map(|n| n.0)
+    }
+}
+
+impl<C> fmt::Debug for Group<C>
+where
+    C: Curve,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self
+            .nodes
+            .iter()
+            .map(|n| write!(f, " {:?} ", n.0))
+            .collect::<fmt::Result>()
+        {
+            Ok(_) => Ok(()),
+            Err(e) => Err(e),
+        }
+    }
+}
+impl<C> From<Vec<C::Point>> for Group<C>
+where
+    C: Curve,
+{
+    fn from(list: Vec<C::Point>) -> Self {
+        let thr = default_threshold(list.len());
+
+        let nodes = list
+            .into_iter()
+            .enumerate()
+            .map(|(i, public)| Node::new(i as Idx, public))
+            .collect();
+
+        Self::new(nodes, thr).expect("threshold should be good here")
+    }
+}
+
+#[cfg(test)]
+mod tests {}

--- a/crates/dkg-core/src/primitives/mod.rs
+++ b/crates/dkg-core/src/primitives/mod.rs
@@ -1,0 +1,91 @@
+pub mod group;
+pub mod states;
+mod status;
+
+use std::fmt;
+use thiserror::Error;
+use threshold_bls::{ecies::EciesError, poly::Idx};
+
+/// The minimum allowed threshold is 51%
+pub fn minimum_threshold(n: usize) -> usize {
+    (((n as f64) / 2.0) + 1.0) as usize
+}
+
+/// The default threshold is 66%
+pub fn default_threshold(n: usize) -> usize {
+    (((n as f64) * 2.0 / 3.0) + 1.0) as usize
+}
+
+/// Result type alias which returns `DKGError`
+pub type DKGResult<A> = Result<A, DKGError>;
+
+#[derive(Debug, PartialEq, Error)]
+pub enum DKGError {
+    /// PublicKeyNotFound is raised when the private key given to the DKG init
+    /// function does not yield a public key that is included in the group.
+    #[error("public key not found in list of participants")]
+    PublicKeyNotFound,
+
+    /// InvalidThreshold is raised when creating a group and specifying an
+    /// invalid threshold. Either the threshold is too low, inferior to
+    /// what `minimum_threshold()` returns or is too large (i.e. larger than the
+    /// number of nodes).
+    #[error("threshold {0} is not in range [{1},{2}]")]
+    InvalidThreshold(usize, usize, usize),
+
+    /// NotEnoughValidShares is raised when the DKG has not successfully
+    /// processed enough shares because they were invalid. In that case, the DKG
+    /// can not continue, the protocol MUST be aborted.
+    #[error("only has {0}/{1} valid shares")]
+    NotEnoughValidShares(usize, usize),
+
+    #[error("only has {0}/{1} required justifications")]
+    NotEnoughJustifications(usize, usize),
+
+    /// Rejected is thrown when the participant is rejected from the final
+    /// output
+    #[error("this participant is rejected from the qualified set")]
+    Rejected,
+}
+
+// TODO: potentially add to the API the ability to streamline the decryption of
+// bundles, and in that case, it would make sense to report those errors.
+#[derive(Debug)]
+struct ShareError {
+    // XXX better structure to put dealer_idx in an outmost struct but leads to
+    // more verbose code. To review?
+    dealer_idx: Idx,
+    error: ShareErrorType,
+}
+
+impl fmt::Display for ShareError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "ShareError(dealer: {}): {}", self.dealer_idx, self.error)
+    }
+}
+
+impl ShareError {
+    fn from(dealer_idx: Idx, error: ShareErrorType) -> Self {
+        Self { dealer_idx, error }
+    }
+}
+
+#[derive(Debug, Error)]
+#[allow(clippy::enum_variant_names)]
+enum ShareErrorType {
+    /// InvalidCipherText returns the error raised when decrypting the encrypted
+    /// share.
+    #[error("Invalid ciphertext")]
+    InvalidCiphertext(EciesError),
+    /// InvalidShare is raised when the share does not corresponds to the public
+    /// polynomial associated.
+    #[error("Share does not match associated public polynomial")]
+    InvalidShare,
+    /// InvalidPublicPolynomial is raised when the public polynomial does not
+    /// have the correct degree. Each public polynomial in the scheme must have
+    /// a degree equals to `threshold - 1` set for the DKG protocol.
+    /// The two fields are (1) the degree of the polynomial and (2) the
+    /// second is the degree it should be,i.e. `threshold - 1`.
+    #[error("polynomial does not have the correct degree, got: {0}, expected {1}")]
+    InvalidPublicPolynomial(usize, usize),
+}

--- a/crates/dkg-core/src/primitives/mod.rs
+++ b/crates/dkg-core/src/primitives/mod.rs
@@ -1,6 +1,6 @@
 pub mod group;
 pub mod states;
-mod status;
+pub mod status;
 
 use std::fmt;
 use thiserror::Error;

--- a/crates/dkg-core/src/primitives/status.rs
+++ b/crates/dkg-core/src/primitives/status.rs
@@ -1,0 +1,89 @@
+use bitvec::{prelude::*, vec::BitVec};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use threshold_bls::poly::Idx;
+
+/// A `Status` holds the claim of a validity or not of a share from the point of
+/// a view of the share holder. A status is sent inside a `Response` during the
+/// second phase of the protocol.
+/// Currently, this protocol only outputs `Complaint` since that is how the protocol
+/// is specified using a synchronous network with a broadcast channel. In
+/// practice, that means any `Response` seen during the second phase is a
+/// `Complaint` from a participant about one of its received share.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum Status {
+    Success,
+    Complaint,
+}
+
+impl From<bool> for Status {
+    fn from(b: bool) -> Self {
+        if b {
+            Status::Success
+        } else {
+            Status::Complaint
+        }
+    }
+}
+
+impl Status {
+    fn to_bool(self) -> bool {
+        self.is_success()
+    }
+
+    pub(super) fn is_success(self) -> bool {
+        match self {
+            Status::Success => true,
+            Status::Complaint => false,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct StatusMatrix(Vec<BitVec>);
+
+impl StatusMatrix {
+    pub fn new(dealers: usize, share_holders: usize, def: Status) -> StatusMatrix {
+        let m = (0..dealers)
+            .map(|i| {
+                let mut bs = bitvec![def.to_bool() as u8; share_holders];
+                bs.set(i, Status::Success.to_bool());
+                bs
+            })
+            .collect();
+        Self(m)
+    }
+
+    pub fn set(&mut self, dealer: Idx, share: Idx, status: Status) {
+        self.0[dealer as usize].set(share as usize, status.to_bool());
+    }
+
+    // return a bitset whose indices are the dealer indexes
+    pub fn get_for_share(&self, share: Idx) -> BitVec {
+        let mut bs = bitvec![0; self.0.len()];
+        for (dealer_idx, shares) in self.0.iter().enumerate() {
+            bs.set(dealer_idx, *shares.get(share as usize).unwrap());
+        }
+        bs
+    }
+
+    pub fn all_true(&self, dealer: Idx) -> bool {
+        self.0[dealer as usize].all()
+    }
+
+    pub fn get_for_dealer(&self, dealer: Idx) -> &BitVec {
+        &self.0[dealer as usize]
+    }
+}
+
+impl fmt::Display for StatusMatrix {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for (dealer, shares) in self.0.iter().enumerate() {
+            match writeln!(f, "-> dealer {}: {:?}", dealer, shares) {
+                Ok(()) => continue,
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/dkg-core/src/primitives/status.rs
+++ b/crates/dkg-core/src/primitives/status.rs
@@ -43,10 +43,13 @@ impl Status {
 pub struct StatusMatrix(Vec<BitVec>);
 
 impl StatusMatrix {
-    pub fn new(dealers: usize, share_holders: usize, def: Status) -> StatusMatrix {
+    /// Returns a NxM Status Matrix (N = dealers, M = share_holders) where all elements
+    /// are initialized to `default`. The elements on the diagonal (i==j) are by initialized
+    /// to `Success`, since the dealer is assumed to succeed
+    pub fn new(dealers: usize, share_holders: usize, default: Status) -> StatusMatrix {
         let m = (0..dealers)
             .map(|i| {
-                let mut bs = bitvec![def.to_bool() as u8; share_holders];
+                let mut bs = bitvec![default.to_bool() as u8; share_holders];
                 bs.set(i, Status::Success.to_bool());
                 bs
             })
@@ -58,7 +61,7 @@ impl StatusMatrix {
         self.0[dealer as usize].set(share as usize, status.to_bool());
     }
 
-    // return a bitset whose indices are the dealer indexes
+    /// Return a bitvec whose indices are the dealer indexes
     pub fn get_for_share(&self, share: Idx) -> BitVec {
         let mut bs = bitvec![0; self.0.len()];
         for (dealer_idx, shares) in self.0.iter().enumerate() {
@@ -67,6 +70,7 @@ impl StatusMatrix {
         bs
     }
 
+    /// Returns `true` if the row corresponding to `dealer` is all 1s.
     pub fn all_true(&self, dealer: Idx) -> bool {
         self.0[dealer as usize].all()
     }

--- a/crates/dkg-core/src/test_helpers.rs
+++ b/crates/dkg-core/src/test_helpers.rs
@@ -1,5 +1,5 @@
 use super::board::BoardPublisher;
-use super::primitives::{BundledJustification, BundledResponses, BundledShares};
+use super::primitives::states::{BundledJustification, BundledResponses, BundledShares};
 use threshold_bls::group::Curve;
 
 /// An in-memory board used for testing


### PR DESCRIPTION
Splits `primitives` to: `group`, `states`, `status`.

- `group` contains all the Group/Node related functionalities
- `states` contains the core DKG logic (which has been slightly refactored to improve readability/performance)
- `status` contains the StatusMatrix implementation

I'll be adding more docs/examples/tests, but preferred to do this refactor first so that lower level modules such as the StatusMatrix can be tested separately from the core DKG logic. That way, any person reviewing the code in the future will be able to focus e.g. in `states.rs` to evaluate the DKG logic, without having to worry about other parts of the codebase which act as utilities.