### PR TITLE
Add tests & docs to the Status Matrix

### DIFF
--- a/crates/dkg-core/src/primitives/mod.rs
+++ b/crates/dkg-core/src/primitives/mod.rs
@@ -1,5 +1,6 @@
 pub mod group;
 pub mod states;
+/// 2D binary array utilities for tracking successful (or not) participation in the DKG
 pub mod status;
 
 use std::fmt;

--- a/crates/dkg-core/src/primitives/states.rs
+++ b/crates/dkg-core/src/primitives/states.rs
@@ -321,7 +321,7 @@ where
         }
 
         let responses = statuses
-            .get_for_share(my_idx)
+            .column(my_idx)
             .into_iter()
             .enumerate()
             .map(|(i, b)| Response {
@@ -462,7 +462,7 @@ where
             let my_idx = self.info.index;
             let bundled_justifications = if !statuses.all_true(my_idx) {
                 let justifications = statuses
-                    .get_for_dealer(my_idx)
+                    .row(my_idx)
                     .iter()
                     .enumerate()
                     .filter_map(|(i, success)| {

--- a/crates/dkg-core/src/primitives/states.rs
+++ b/crates/dkg-core/src/primitives/states.rs
@@ -321,7 +321,7 @@ where
         }
 
         let responses = statuses
-            .column(my_idx)
+            .get_for_share(my_idx)
             .into_iter()
             .enumerate()
             .map(|(i, b)| Response {
@@ -462,7 +462,7 @@ where
             let my_idx = self.info.index;
             let bundled_justifications = if !statuses.all_true(my_idx) {
                 let justifications = statuses
-                    .row(my_idx)
+                    .get_for_dealer(my_idx)
                     .iter()
                     .enumerate()
                     .filter_map(|(i, success)| {

--- a/crates/dkg-core/src/primitives/status.rs
+++ b/crates/dkg-core/src/primitives/status.rs
@@ -47,14 +47,14 @@ impl Status {
 /// ```rust
 /// use dkg_core::primitives::status::{Status, StatusMatrix};
 ///
-/// // iniitializes the matrix (diagonal elements are always set to Status::Success)
+/// // initializes the matrix (diagonal elements are always set to Status::Success)
 /// let mut matrix = StatusMatrix::new(3, 5, Status::Complaint);
 ///
 /// // get the matrix's first row
-/// let row = matrix.row(1);
+/// let row = matrix.get_for_dealer(1);
 ///
 /// // get the matrix's first column
-/// let column = matrix.row(1);
+/// let column = matrix.get_for_dealer(1);
 ///
 /// // set a value in the matrix
 /// matrix.set(1, 2, Status::Complaint);
@@ -152,8 +152,7 @@ impl StatusMatrix {
     /// # Panics
     ///
     /// If the `share` index is greater than the number of shareholders
-    pub fn column(&self, share: Idx) -> BitVec {
-        // each column has `rows.length` elements
+    pub fn get_for_share(&self, share: Idx) -> BitVec {
         let mut col = bitvec![0; self.0.len()];
 
         for (dealer_idx, shares) in self.0.iter().enumerate() {
@@ -170,17 +169,17 @@ impl StatusMatrix {
     ///
     /// # Panics
     ///
-    /// If the `dealer` index is greater than the number of rows
+    /// If the `dealer` index is greater than the number of dealers
     pub fn all_true(&self, dealer: Idx) -> bool {
-        self.row(dealer).all()
+        self.get_for_dealer(dealer).all()
     }
 
-    /// Returns the row corresponding to `dealer`
+    /// Returns the row corresponding to the dealer at `dealer`
     ///
     /// # Panics
     ///
-    /// If the `dealer` index is greater than the number of rows
-    pub fn row(&self, dealer: Idx) -> &BitVec {
+    /// If the `dealer` index is greater than the number of dealers
+    pub fn get_for_dealer(&self, dealer: Idx) -> &BitVec {
         self.0
             .get(dealer as usize)
             .expect("dealer index out of bounds")
@@ -194,8 +193,8 @@ mod tests {
     #[test]
     fn diagonal_success() {
         let matrix = StatusMatrix::new(10, 10, Status::Complaint);
-        for (i, row) in matrix.into_iter().enumerate() {
-            assert_eq!(row.get(i).unwrap(), &true);
+        for (i, get_for_dealer) in matrix.into_iter().enumerate() {
+            assert_eq!(get_for_dealer.get(i).unwrap(), &true);
         }
     }
 
@@ -210,23 +209,23 @@ mod tests {
     }
 
     #[test]
-    fn get_row() {
+    fn get_for_dealer() {
         let matrix = StatusMatrix::new(3, 3, Status::Complaint);
-        let row = matrix.row(1);
-        assert_eq!(row, &bitvec![0, 1, 0]);
+        let get_for_dealer = matrix.get_for_dealer(1);
+        assert_eq!(get_for_dealer, &bitvec![0, 1, 0]);
     }
 
     #[test]
     #[should_panic(expected = "dealer index out of bounds")]
     fn dealer_out_of_bounds() {
         let matrix = StatusMatrix::new(3, 5, Status::Complaint);
-        matrix.row(3);
+        matrix.get_for_dealer(3);
     }
 
     #[test]
-    fn get_column() {
+    fn get_for_share() {
         let matrix = StatusMatrix::new(2, 3, Status::Complaint);
-        let col = matrix.column(2);
+        let col = matrix.get_for_share(2);
         assert_eq!(col, bitvec![0, 0]);
     }
 
@@ -234,7 +233,7 @@ mod tests {
     #[should_panic(expected = "share index out of bounds")]
     fn share_out_of_bounds() {
         let matrix = StatusMatrix::new(3, 5, Status::Complaint);
-        matrix.column(5);
+        matrix.get_for_share(5);
     }
 
     #[test]

--- a/crates/dkg-core/src/primitives/status.rs
+++ b/crates/dkg-core/src/primitives/status.rs
@@ -39,14 +39,47 @@ impl Status {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Hash, PartialEq, Eq)]
 pub struct StatusMatrix(Vec<BitVec>);
 
+impl AsRef<[BitVec]> for StatusMatrix {
+    fn as_ref(&self) -> &[BitVec] {
+        &self.0
+    }
+}
+
+impl IntoIterator for StatusMatrix {
+    type Item = BitVec;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl fmt::Display for StatusMatrix {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for (dealer, shares) in self.0.iter().enumerate() {
+            writeln!(f, "-> dealer {}: {}", dealer, shares)?;
+        }
+        Ok(())
+    }
+}
+
 impl StatusMatrix {
-    /// Returns a NxM Status Matrix (N = dealers, M = share_holders) where all elements
+    /// Returns a MxN Status Matrix (M = dealers, N = share_holders) where all elements
     /// are initialized to `default`. The elements on the diagonal (i==j) are by initialized
     /// to `Success`, since the dealer is assumed to succeed
+    ///
+    /// # Panics
+    ///
+    /// If `dealers > share_holders`
     pub fn new(dealers: usize, share_holders: usize, default: Status) -> StatusMatrix {
+        debug_assert!(
+            dealers <= share_holders,
+            "dealers cannot be more than share holders"
+        );
+
         let m = (0..dealers)
             .map(|i| {
                 let mut bs = bitvec![default.to_bool() as u8; share_holders];
@@ -61,33 +94,99 @@ impl StatusMatrix {
         self.0[dealer as usize].set(share as usize, status.to_bool());
     }
 
-    /// Return a bitvec whose indices are the dealer indexes
+    /// Returns the column corresponding to the shareholder at `share`
+    /// # Panics
+    ///
+    /// If the `share` index is greater than the number of shareholders
     pub fn get_for_share(&self, share: Idx) -> BitVec {
-        let mut bs = bitvec![0; self.0.len()];
+        // each column has `rows.length` elements
+        let mut col = bitvec![0; self.0.len()];
+
         for (dealer_idx, shares) in self.0.iter().enumerate() {
-            bs.set(dealer_idx, *shares.get(share as usize).unwrap());
+            let share_bit = shares
+                .get(share as usize)
+                .expect("share index out of bounds");
+            col.set(dealer_idx, *share_bit);
         }
-        bs
+
+        col
     }
 
     /// Returns `true` if the row corresponding to `dealer` is all 1s.
+    ///
+    /// # Panics
+    ///
+    /// If the `dealer` index is greater than the number of rows
     pub fn all_true(&self, dealer: Idx) -> bool {
-        self.0[dealer as usize].all()
+        self.get_for_dealer(dealer).all()
     }
 
+    /// Returns the row corresponding to `dealer`
+    ///
+    /// # Panics
+    ///
+    /// If the `dealer` index is greater than the number of rows
     pub fn get_for_dealer(&self, dealer: Idx) -> &BitVec {
-        &self.0[dealer as usize]
+        self.0
+            .get(dealer as usize)
+            .expect("dealer index out of bounds")
     }
 }
 
-impl fmt::Display for StatusMatrix {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        for (dealer, shares) in self.0.iter().enumerate() {
-            match writeln!(f, "-> dealer {}: {:?}", dealer, shares) {
-                Ok(()) => continue,
-                Err(e) => return Err(e),
-            }
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn diagonal_success() {
+        let matrix = StatusMatrix::new(10, 10, Status::Complaint);
+        for (i, row) in matrix.into_iter().enumerate() {
+            assert_eq!(row.get(i).unwrap(), &true);
         }
-        Ok(())
+    }
+
+    #[test]
+    fn get_row() {
+        let matrix = StatusMatrix::new(3, 3, Status::Complaint);
+        let row = matrix.get_for_dealer(1);
+        assert_eq!(row, &bitvec![0, 1, 0]);
+    }
+
+    #[test]
+    #[should_panic(expected = "dealer index out of bounds")]
+    fn dealer_out_of_bounds() {
+        let matrix = StatusMatrix::new(3, 5, Status::Complaint);
+        matrix.get_for_dealer(3);
+    }
+
+    #[test]
+    fn get_column() {
+        // 2x3 array's has columns of length 2
+        let matrix = StatusMatrix::new(2, 3, Status::Complaint);
+        let col = matrix.get_for_share(2);
+        assert_eq!(col, bitvec![0, 0]);
+    }
+
+    #[test]
+    #[should_panic(expected = "share index out of bounds")]
+    fn share_out_of_bounds() {
+        let matrix = StatusMatrix::new(3, 5, Status::Complaint);
+        matrix.get_for_share(5);
+    }
+
+    #[test]
+    fn display() {
+        let matrix = StatusMatrix::new(3, 3, Status::Complaint);
+        let s = matrix.to_string();
+        assert_eq!(
+            s,
+            "-> dealer 0: [100]\n-> dealer 1: [010]\n-> dealer 2: [001]\n"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "dealers cannot be more than share holders")]
+    fn dealers_more_than_shareholders_panics() {
+        StatusMatrix::new(6, 5, Status::Complaint);
     }
 }


### PR DESCRIPTION
As title. Also I believe that the method names are much more intuitive and simpler as `rows` and `columns`. It wasn't immediately obvious to me that this didn't support more shares than dealers, so I've documented that