### PR TITLE
Error Handling & Docs

### DIFF
--- a/crates/dkg-core/src/board.rs
+++ b/crates/dkg-core/src/board.rs
@@ -10,6 +10,7 @@ use threshold_bls::group::Curve;
 /// Trait which must be implemented for writing to the board. This trait assumes
 /// an authenticated channel.
 pub trait BoardPublisher<C: Curve> {
+    /// Error raised when trying to publish data to the board
     type Error;
 
     /// Publishes the shares to the board

--- a/crates/dkg-core/src/lib.rs
+++ b/crates/dkg-core/src/lib.rs
@@ -1,5 +1,19 @@
+//! # DKG Core
+//!
+//! The DKG is based on the [Secure Distributed Key Generation for Discrete-Log Based Cryptosystems
+//! ](https://link.springer.com/article/10.1007/s00145-006-0347-3) paper.
+//!
+//! The implementation is a state machine which has Phases 0 to 3. Phase 3 is only reachable if any of the
+//! n parties does not publish its shares in the first phase. If less than t parties participate in any stage,
+//! the DKG fails.
+
+/// Board trait and implementations for publishing data from each DKG phase
 pub mod board;
+
+/// Higher level objects for running a 3-phase DKG
 pub mod node;
+
+/// Primitives for building a DKG
 pub mod primitives;
 
 #[cfg(test)]

--- a/crates/dkg-core/src/primitives/group.rs
+++ b/crates/dkg-core/src/primitives/group.rs
@@ -1,40 +1,27 @@
 use super::{default_threshold, minimum_threshold, DKGError, DKGResult};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use std::fmt;
 use threshold_bls::{group::Curve, poly::Idx};
 
 /// Node is a participant in the DKG protocol. In a DKG protocol, each
 /// participant must be identified both by an index and a public key. At the end
 /// of the protocol, if sucessful, the index is used to verify the validity of
 /// the share this node holds.
-#[derive(Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 pub struct Node<C: Curve>(Idx, C::Point);
 
-impl<C> Node<C>
-where
-    C: Curve,
-{
+impl<C: Curve> Node<C> {
     pub fn new(index: Idx, public: C::Point) -> Self {
         Self(index, public)
     }
 }
 
-impl<C> fmt::Debug for Node<C>
-where
-    C: Curve,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Node{{{} -> {:?} }}", self.0, self.1)
-    }
-}
-
-impl<C> Node<C>
-where
-    C: Curve,
-{
+impl<C: Curve> Node<C> {
+    /// Returns the node's index
     pub fn id(&self) -> Idx {
         self.0
     }
+
+    /// Returns the node's public key
     pub fn key(&self) -> &C::Point {
         &self.1
     }
@@ -45,10 +32,12 @@ where
 /// new group that contains members that succesfully ran the protocol. When
 /// creating a new group using the `from()` or `from_list()`method, the module
 /// sets the threshold to the output of `default_threshold()`.
-#[derive(Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 #[serde(bound = "C::Scalar: DeserializeOwned")]
 pub struct Group<C: Curve> {
+    /// The vector of nodes in the group
     pub nodes: Vec<Node<C>>,
+    /// The minimum number of nodes required to participate in the DKG for this group
     pub threshold: usize,
 }
 
@@ -96,22 +85,6 @@ where
     }
 }
 
-impl<C> fmt::Debug for Group<C>
-where
-    C: Curve,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self
-            .nodes
-            .iter()
-            .map(|n| write!(f, " {:?} ", n.0))
-            .collect::<fmt::Result>()
-        {
-            Ok(_) => Ok(()),
-            Err(e) => Err(e),
-        }
-    }
-}
 impl<C> From<Vec<C::Point>> for Group<C>
 where
     C: Curve,
@@ -128,6 +101,3 @@ where
         Self::new(nodes, thr).expect("threshold should be good here")
     }
 }
-
-#[cfg(test)]
-mod tests {}

--- a/crates/dkg-core/src/primitives/mod.rs
+++ b/crates/dkg-core/src/primitives/mod.rs
@@ -24,6 +24,7 @@ pub fn default_threshold(n: usize) -> usize {
 pub type DKGResult<A> = Result<A, DKGError>;
 
 #[derive(Debug, Error)]
+/// Errors which may occur during the DKG
 pub enum DKGError {
     /// PublicKeyNotFound is raised when the private key given to the DKG init
     /// function does not yield a public key that is included in the group.
@@ -46,15 +47,16 @@ pub enum DKGError {
     #[error("only has {0}/{1} required justifications")]
     NotEnoughJustifications(usize, usize),
 
-    /// Rejected is thrown when the participant is rejected from the final
+    /// Rejected is raised when the participant is rejected from the final
     /// output
     #[error("this participant is rejected from the qualified set")]
     Rejected,
 
-    /// De(serialization) failed
+    /// BincodeError is raised when de(serialization) by bincode fails
     #[error("de(serialization failed: {0})")]
     BincodeError(#[from] bincode::Error),
 
+    /// ShareError is raised when a share is being processed
     #[error(transparent)]
     ShareError(#[from] ShareError),
 }

--- a/crates/dkg-core/src/primitives/mod.rs
+++ b/crates/dkg-core/src/primitives/mod.rs
@@ -3,7 +3,6 @@ pub mod states;
 /// 2D binary array utilities for tracking successful (or not) participation in the DKG
 pub mod status;
 
-use std::fmt;
 use thiserror::Error;
 use threshold_bls::{ecies::EciesError, poly::Idx};
 
@@ -20,7 +19,7 @@ pub fn default_threshold(n: usize) -> usize {
 /// Result type alias which returns `DKGError`
 pub type DKGResult<A> = Result<A, DKGError>;
 
-#[derive(Debug, PartialEq, Error)]
+#[derive(Debug, Error)]
 pub enum DKGError {
     /// PublicKeyNotFound is raised when the private key given to the DKG init
     /// function does not yield a public key that is included in the group.
@@ -47,46 +46,31 @@ pub enum DKGError {
     /// output
     #[error("this participant is rejected from the qualified set")]
     Rejected,
-}
 
-// TODO: potentially add to the API the ability to streamline the decryption of
-// bundles, and in that case, it would make sense to report those errors.
-#[derive(Debug)]
-struct ShareError {
-    // XXX better structure to put dealer_idx in an outmost struct but leads to
-    // more verbose code. To review?
-    dealer_idx: Idx,
-    error: ShareErrorType,
-}
+    /// De(serialization) failed
+    #[error("de(serialization failed: {0})")]
+    BincodeError(#[from] bincode::Error),
 
-impl fmt::Display for ShareError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        writeln!(f, "ShareError(dealer: {}): {}", self.dealer_idx, self.error)
-    }
-}
-
-impl ShareError {
-    fn from(dealer_idx: Idx, error: ShareErrorType) -> Self {
-        Self { dealer_idx, error }
-    }
+    #[error(transparent)]
+    ShareError(#[from] ShareError),
 }
 
 #[derive(Debug, Error)]
 #[allow(clippy::enum_variant_names)]
-enum ShareErrorType {
+pub enum ShareError {
     /// InvalidCipherText returns the error raised when decrypting the encrypted
     /// share.
-    #[error("Invalid ciphertext")]
-    InvalidCiphertext(EciesError),
+    #[error("[dealer: {0}] Invalid ciphertext")]
+    InvalidCiphertext(Idx, EciesError),
     /// InvalidShare is raised when the share does not corresponds to the public
     /// polynomial associated.
-    #[error("Share does not match associated public polynomial")]
-    InvalidShare,
+    #[error("[dealer: {0}] Share does not match associated public polynomial")]
+    InvalidShare(Idx),
     /// InvalidPublicPolynomial is raised when the public polynomial does not
     /// have the correct degree. Each public polynomial in the scheme must have
     /// a degree equals to `threshold - 1` set for the DKG protocol.
     /// The two fields are (1) the degree of the polynomial and (2) the
     /// second is the degree it should be,i.e. `threshold - 1`.
-    #[error("polynomial does not have the correct degree, got: {0}, expected {1}")]
-    InvalidPublicPolynomial(usize, usize),
+    #[error("[dealer: {0}] polynomial does not have the correct degree, got: {1}, expected {2}")]
+    InvalidPublicPolynomial(Idx, usize, usize),
 }

--- a/crates/dkg-core/src/primitives/mod.rs
+++ b/crates/dkg-core/src/primitives/mod.rs
@@ -1,5 +1,9 @@
+/// Primitives for grouping together vectors of nodes with an associated threshold
 pub mod group;
+
+/// Core DKG logic, implemented as a state machine
 pub mod states;
+
 /// 2D binary array utilities for tracking successful (or not) participation in the DKG
 pub mod status;
 
@@ -57,6 +61,7 @@ pub enum DKGError {
 
 #[derive(Debug, Error)]
 #[allow(clippy::enum_variant_names)]
+/// Error which may occur while processing a share in Phase 1
 pub enum ShareError {
     /// InvalidCipherText returns the error raised when decrypting the encrypted
     /// share.

--- a/crates/dkg-core/src/primitives/states.rs
+++ b/crates/dkg-core/src/primitives/states.rs
@@ -168,6 +168,7 @@ impl<C: Curve> DKG<C> {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// A response which gets generated when processing the shares from Phase 1
 pub struct Response {
     /// The index of the dealer (the person that created the share)
     pub dealer_idx: Idx,
@@ -191,7 +192,8 @@ pub struct BundledResponses {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound = "C::Scalar: DeserializeOwned")]
 /// DKG Stage which waits to receive the shares from the previous phase's participants
-/// as input
+/// as input. After processing the shares, if there were any complaints it will generate
+/// a bundle of responses for the next phase.
 pub struct DKGWaitingShare<C: Curve> {
     /// Metadata about the DKG
     info: DKGInfo<C>,
@@ -410,6 +412,9 @@ pub struct BundledJustification<C: Curve> {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound = "C::Scalar: DeserializeOwned")]
+/// DKG Stage which waits to receive the responses from the previous phase's participants
+/// as input. The responses will be processed and justifications may be generated as a byproduct
+/// if there are complaints.
 pub struct DKGWaitingResponse<C: Curve> {
     info: DKGInfo<C>,
     dist_share: C::Scalar,
@@ -548,6 +553,8 @@ impl<C: Curve> DKGWaitingResponse<C> {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound = "C::Scalar: DeserializeOwned")]
+/// DKG Stage which waits to receive the justifications from the previous phase's participants
+/// as input to produce either the final DKG Output, or an error.
 pub struct DKGWaitingJustification<C: Curve> {
     // TODO: transform that into one info variable that gets default value for
     // missing parts depending in the round of the protocol.


### PR DESCRIPTION
- Add serialization errors
- Combines the `ShareErrorType` and `ShareError`
- Derives Debugs instead of manually implementing them
- Adds docs for the rest of the repo (everything public has a docstring now, although they can be improved with more specific information / examples)