### PR TITLE
Adds more methods to wasm and fixes compilation to play nice with FFI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1425,6 +1425,7 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "bls-crypto",
+ "cfg-if",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "serde",

--- a/crates/threshold-bls-ffi/Cargo.toml
+++ b/crates/threshold-bls-ffi/Cargo.toml
@@ -19,5 +19,7 @@ wasm-bindgen = { version = "0.2.60", optional = true }
 bincode = { version = "1.2.1", default-features = false }
 serde = { version = "1.0.106", default-features =  false }
 
+cfg-if = "0.1"
+
 [features]
 wasm = ["wasm-bindgen"]

--- a/crates/threshold-bls-ffi/src/lib.rs
+++ b/crates/threshold-bls-ffi/src/lib.rs
@@ -1,20 +1,25 @@
 // add this so that we can be more explicit about unsafe calls inside unsafe functions
 #![allow(unused_unsafe)]
 
-pub mod ffi;
+extern crate cfg_if;
 
-#[cfg(feature = "wasm")]
-pub mod wasm;
+cfg_if::cfg_if! {
+    if #[cfg(feature = "wasm")] {
+        pub mod wasm;
+    } else {
+        pub mod ffi;
+        pub(crate) type Signature = <SigScheme as Scheme>::Signature;
+        pub(crate) const PUBKEY_LEN: usize = 96;
+        pub(crate) const PRIVKEY_LEN: usize = 32;
+    }
+}
 
 use threshold_bls::{poly::Idx, schemes::bls12_377::G2Scheme as SigScheme, sig::Scheme};
 
 pub(crate) type PublicKey = <SigScheme as Scheme>::Public;
 pub(crate) type PrivateKey = <SigScheme as Scheme>::Private;
-pub(crate) type Signature = <SigScheme as Scheme>::Signature;
 
 pub(crate) const VEC_LENGTH: usize = 8;
 pub(crate) const SIGNATURE_LEN: usize = 48;
-pub(crate) const PUBKEY_LEN: usize = 96;
-pub(crate) const PRIVKEY_LEN: usize = 32;
 pub(crate) const PARTIAL_SIG_LENGTH: usize =
     VEC_LENGTH + SIGNATURE_LEN + std::mem::size_of::<Idx>();

--- a/crates/threshold-bls-ffi/src/wasm.rs
+++ b/crates/threshold-bls-ffi/src/wasm.rs
@@ -389,48 +389,88 @@ mod tests {
 
     #[test]
     fn threshold_wasm() {
-        let seed = b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-        let keys = threshold_keygen(5, 3, &seed[..]);
-
-        let msg = vec![1, 2, 3, 4, 6];
-
-        let sig1 = partial_sign(&keys.get_share(0), &msg).unwrap();
-        let sig2 = partial_sign(&keys.get_share(1), &msg).unwrap();
-        let sig3 = partial_sign(&keys.get_share(2), &msg).unwrap();
-
-        partial_verify(&keys.polynomial(), &msg, &sig1).unwrap();
-        partial_verify(&keys.polynomial(), &msg, &sig2).unwrap();
-        partial_verify(&keys.polynomial(), &msg, &sig3).unwrap();
-
-        let concatenated = [sig1, sig2, sig3].concat();
-        let asig = combine(3, concatenated).unwrap();
-
-        verify(&keys.threshold_public_key(), &msg, &asig).unwrap();
+        threshold_wasm_should_blind(true);
+        threshold_wasm_should_blind(false);
     }
 
     #[test]
-    fn blinded_threshold_wasm() {
+    fn signing() {
+        wasm_should_blind(true);
+        wasm_should_blind(false);
+
+    }
+
+    fn wasm_should_blind(should_blind: bool) {
         let seed = b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-        let keys = threshold_keygen(5, 3, &seed[..]);
+        let keypair = keygen(seed.to_vec());
 
         let msg = vec![1, 2, 3, 4, 6];
         let key = b"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
-        let blinded_message = blind(msg.clone(), &key[..]);
-        let blinded_msg = blinded_message.message.clone();
 
-        let sig1 = partial_sign_blinded_message(&keys.get_share(0), &blinded_msg).unwrap();
-        let sig2 = partial_sign_blinded_message(&keys.get_share(1), &blinded_msg).unwrap();
-        let sig3 = partial_sign_blinded_message(&keys.get_share(2), &blinded_msg).unwrap();
+        let (message, token) = if should_blind {
+            let ret = blind(msg.clone(), &key[..]);
+            (ret.message.clone(), ret.blinding_factor())
+        } else {
+            (msg.clone(), vec![])
+        };
+        
+        let sign_fn = if should_blind {
+            sign_blinded_message
+        } else {
+            sign
+        };
 
-        partial_verify_blind_signature(&keys.polynomial(), &blinded_msg, &sig1).unwrap();
-        partial_verify_blind_signature(&keys.polynomial(), &blinded_msg, &sig2).unwrap();
-        partial_verify_blind_signature(&keys.polynomial(), &blinded_msg, &sig3).unwrap();
+        let sig = sign_fn(&keypair.private_key(), &message).unwrap();
 
-        let concatenated = [sig1, sig2, sig3].concat();
+        if should_blind {
+            verify_blind_signature(&keypair.public_key(), &message, &sig).unwrap();
+            let unblinded = unblind(&sig, &token).unwrap();
+            verify(&keypair.public_key(), &msg, &unblinded).unwrap();
+        } else {
+            verify(&keypair.public_key(), &msg, &sig).unwrap();
+        }
+    }
+
+    fn threshold_wasm_should_blind(should_blind: bool) {
+        let (n, t) = (5, 3);
+        let seed = b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let keys = threshold_keygen(n, t, &seed[..]);
+
+        let msg = vec![1, 2, 3, 4, 6];
+        let key = b"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+        let (message, token) = if should_blind {
+            let ret = blind(msg.clone(), &key[..]);
+            (ret.message.clone(), ret.blinding_factor())
+        } else {
+            (msg.clone(), vec![])
+        };
+        
+        let sign_fn = if should_blind {
+            partial_sign_blinded_message
+        } else {
+            partial_sign
+        };
+
+        let verify_fn = if should_blind {
+            partial_verify_blind_signature
+        } else {
+            partial_verify
+        };
+
+        let sigs = (0..t).map(|i| sign_fn(&keys.get_share(i), &message).unwrap()).collect::<Vec<Vec<_>>>();
+
+        sigs.iter().for_each(|sig| verify_fn(&keys.polynomial(), &message, &sig).unwrap());
+
+        let concatenated = sigs.concat();
         let asig = combine(3, concatenated).unwrap();
 
-        let unblinded = unblind(&asig, &blinded_message.blinding_factor()).unwrap();
-
-        verify(&keys.threshold_public_key(), &msg, &unblinded).unwrap();
+        if should_blind {
+            verify_blind_signature(&keys.threshold_public_key(), &message, &asig).unwrap();
+            let unblinded = unblind(&asig, &token).unwrap();
+            verify(&keys.threshold_public_key(), &msg, &unblinded).unwrap();
+        } else {
+            verify(&keys.threshold_public_key(), &msg, &asig).unwrap();
+        }
     }
 }


### PR DESCRIPTION
* Methods from `ffi.rs` conflicted with methods from WASM, so now they're behind a cfg_if.
* WASM now exports `sign_blinded_message`, `verify_blind_signature`.

```
error: symbol `blind` is already defined
  --> crates/threshold-bls-ffi/src/wasm.rs:20:1
   |
20 | #[wasm_bindgen]
   | ^^^^^^^^^^^^^^^
   |
   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
```