### PR TITLE
Expose publishing all responses instead of just complaints

### DIFF
--- a/crates/dkg-cli/src/user/actions.rs
+++ b/crates/dkg-cli/src/user/actions.rs
@@ -44,7 +44,7 @@ where
     let group_file = File::open(opts.group)?;
     let group: Group<C> = bincode::deserialize_from(group_file)?;
 
-    let phase0 = Phase0::new(pk, group)?;
+    let phase0 = Phase0::new(pk, group, opts.publish_all)?;
 
     // writes the shares to the board
     let mut board = File::create(opts.output)?;

--- a/crates/dkg-cli/src/user/opts.rs
+++ b/crates/dkg-cli/src/user/opts.rs
@@ -60,6 +60,12 @@ pub struct PublishSharesOpts {
 
     #[options(help = "the shares will be written to this file")]
     pub output: String,
+
+    #[options(
+        help = "publish all responses or just the complaints? Defaults to publishing complaints only",
+        default = "false"
+    )]
+    pub publish_all: bool,
 }
 
 #[derive(Debug, Options, Clone)]


### PR DESCRIPTION
Setting `publish_all = true` allows you to relax your synchronicity wait.

If you only wait for complaints, you have to wait X minutes until phase 1 finishes to guarantee you got all the complaints. If you get all the successes, you don't have to wait. h/t @kobigurk 