### PR TITLE
Removing hash_without_sign

### DIFF
--- a/crates/dkg-core/src/node.rs
+++ b/crates/dkg-core/src/node.rs
@@ -179,8 +179,7 @@ mod tests {
         curve::bls12381::{self, PairingCurve as BLS12_381},
         curve::zexe::{self as bls12_377, PairingCurve as BLS12_377},
         poly::Idx,
-        sig::{BlindThresholdScheme, G1Scheme, G2Scheme, Scheme,ThresholdScheme,
-        SignatureScheme},
+        sig::{BlindThresholdScheme, G1Scheme, G2Scheme, Scheme, SignatureScheme, ThresholdScheme},
     };
 
     // helper to simulate a phase0 where a participant does not publish their
@@ -208,7 +207,9 @@ mod tests {
         C: Curve,
         // We need to bind the Curve's Point and Scalars to the Scheme
         S: Scheme<Public = <C as Curve>::Point, Private = <C as Curve>::Scalar>
-            + BlindThresholdScheme + ThresholdScheme + SignatureScheme,
+            + BlindThresholdScheme
+            + ThresholdScheme
+            + SignatureScheme,
     {
         let msg = rand::random::<[u8; 32]>().to_vec();
 

--- a/crates/threshold-bls-ffi/src/ffi.rs
+++ b/crates/threshold-bls-ffi/src/ffi.rs
@@ -6,8 +6,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use threshold_bls::{
     poly::{Idx as Index, Poly},
     sig::{
-        BlindScheme, Scheme, Share, SignatureScheme, ThresholdScheme, Token, 
-        BlindThresholdScheme
+        BlindScheme, BlindThresholdScheme, Scheme, Share, SignatureScheme, ThresholdScheme, Token,
     },
 };
 

--- a/crates/threshold-bls-ffi/src/ffi.rs
+++ b/crates/threshold-bls-ffi/src/ffi.rs
@@ -6,8 +6,8 @@ use serde::{de::DeserializeOwned, Serialize};
 use threshold_bls::{
     poly::{Idx as Index, Poly},
     sig::{
-        Blinder, Scheme, Share, SignatureScheme, SignatureSchemeExt, ThresholdScheme,
-        ThresholdSchemeExt, Token,
+        BlindScheme, Scheme, Share, SignatureScheme, ThresholdScheme, Token, 
+        BlindThresholdScheme
     },
 };
 
@@ -60,7 +60,7 @@ pub unsafe extern "C" fn blind(
 
     // blind the message with this randomness
     let message = <&[u8]>::from(unsafe { &*message });
-    let (blinding_factor, blinded_message_bytes) = SigScheme::blind(&message, &mut rng);
+    let (blinding_factor, blinded_message_bytes) = SigScheme::blind_msg(&message, &mut rng);
 
     unsafe { *blinded_message_out = Buffer::from(&blinded_message_bytes[..]) };
     std::mem::forget(blinded_message_bytes);
@@ -95,7 +95,7 @@ pub unsafe extern "C" fn unblind(
     let blinded_signature = <&[u8]>::from(unsafe { &*blinded_signature });
     let blinding_factor = unsafe { &*blinding_factor };
 
-    let sig = match SigScheme::unblind(blinding_factor, blinded_signature) {
+    let sig = match SigScheme::unblind_sig(blinding_factor, blinded_signature) {
         Ok(s) => s,
         Err(_) => return false,
     };
@@ -134,7 +134,7 @@ pub unsafe extern "C" fn verify(
 
     // checks the signature on the message hash
     let signature = <&[u8]>::from(unsafe { &*signature });
-    <SigScheme as SignatureScheme>::verify(public_key, &message, signature).is_ok()
+    SigScheme::verify(public_key, &message, signature).is_ok()
 }
 
 ///////////////////////////////////////////////////////////////////////////
@@ -194,7 +194,7 @@ pub unsafe extern "C" fn sign_blinded_message(
     let private_key = unsafe { &*private_key };
     let message = <&[u8]>::from(unsafe { &*message });
 
-    let sig = match SigScheme::sign_without_hashing(&private_key, &message) {
+    let sig = match SigScheme::blind_sign(&private_key, &message) {
         Ok(s) => s,
         Err(_) => return false,
     };
@@ -258,7 +258,7 @@ pub unsafe extern "C" fn partial_sign_blinded_message(
 
     let share = unsafe { &*share };
     let message = unsafe { &*blinded_message };
-    let sig = match SigScheme::partial_sign_without_hashing(share, <&[u8]>::from(message)) {
+    let sig = match SigScheme::sign_blind_partial(share, <&[u8]>::from(message)) {
         Ok(s) => s,
         Err(_) => return false,
     };
@@ -326,7 +326,7 @@ pub unsafe extern "C" fn partial_verify_blind_signature(
     let blinded_message = <&[u8]>::from(unsafe { &*blinded_message });
     let signature = <&[u8]>::from(unsafe { &*signature });
 
-    SigScheme::partial_verify_without_hashing(&polynomial, blinded_message, signature).is_ok()
+    SigScheme::verify_blind_partial(&polynomial, blinded_message, signature).is_ok()
 }
 
 /// Combines a flattened vector of partial signatures to a single threshold signature

--- a/crates/threshold-bls-ffi/src/wasm.rs
+++ b/crates/threshold-bls-ffi/src/wasm.rs
@@ -6,7 +6,9 @@ use rand_core::{RngCore, SeedableRng};
 
 use threshold_bls::{
     poly::{Idx as Index, Poly},
-    sig::{BlindScheme, Scheme, Share, SignatureScheme, ThresholdScheme, Token},
+    sig::{
+        BlindScheme, BlindThresholdScheme, Scheme, Share, SignatureScheme, ThresholdScheme, Token,
+    },
 };
 
 use crate::*;

--- a/crates/threshold-bls-ffi/src/wasm.rs
+++ b/crates/threshold-bls-ffi/src/wasm.rs
@@ -6,7 +6,7 @@ use rand_core::{RngCore, SeedableRng};
 
 use threshold_bls::{
     poly::{Idx as Index, Poly},
-    sig::{Blinder, Scheme, Share, SignatureScheme, SignatureSchemeExt, ThresholdScheme, ThresholdSchemeExt, Token},
+    sig::{BlindScheme, Scheme, Share, SignatureScheme, ThresholdScheme, Token},
 };
 
 use crate::*;
@@ -33,7 +33,7 @@ pub fn blind(message: Vec<u8>, seed: &[u8]) -> BlindedMessage {
     let mut rng = get_rng(&seed);
 
     // blind the message with this randomness
-    let (blinding_factor, blinded_message) = SigScheme::blind(&message, &mut rng);
+    let (blinding_factor, blinded_message) = SigScheme::blind_msg(&message, &mut rng);
 
     // return the message and the blinding_factor used for blinding
     BlindedMessage {
@@ -58,7 +58,7 @@ pub fn unblind(blinded_signature: &[u8], blinding_factor_buf: &[u8]) -> Result<V
             JsValue::from_str(&format!("could not deserialize blinding factor {}", err))
         })?;
 
-    SigScheme::unblind(&blinding_factor, blinded_signature)
+    SigScheme::unblind_sig(&blinding_factor, blinded_signature)
         .map_err(|err| JsValue::from_str(&format!("could not unblind signature {}", err)))
 }
 
@@ -78,10 +78,9 @@ pub fn verify(public_key_buf: &[u8], message: &[u8], signature: &[u8]) -> Result
         .map_err(|err| JsValue::from_str(&format!("could not deserialize public key {}", err)))?;
 
     // checks the signature on the message hash
-    <SigScheme as SignatureScheme>::verify(&public_key, &message, &signature)
+    SigScheme::verify(&public_key, &message, &signature)
         .map_err(|err| JsValue::from_str(&format!("signature verification failed: {}", err)))
 }
-
 
 #[wasm_bindgen(js_name = verifyBlindSignature)]
 /// Verifies the signature after it has been unblinded without hashing. Users will call this on the
@@ -94,12 +93,16 @@ pub fn verify(public_key_buf: &[u8], message: &[u8], signature: &[u8]) -> Result
 /// # Throws
 ///
 /// - If verification fails
-pub fn verify_blind_signature(public_key_buf: &[u8], message: &[u8], signature: &[u8]) -> Result<()> {
+pub fn verify_blind_signature(
+    public_key_buf: &[u8],
+    message: &[u8],
+    signature: &[u8],
+) -> Result<()> {
     let public_key: PublicKey = bincode::deserialize(&public_key_buf)
         .map_err(|err| JsValue::from_str(&format!("could not deserialize public key {}", err)))?;
 
     // checks the signature on the message hash
-    SigScheme::verify_without_hashing(&public_key, &message, &signature)
+    SigScheme::blind_verify(&public_key, &message, &signature)
         .map_err(|err| JsValue::from_str(&format!("signature verification failed: {}", err)))
 }
 
@@ -131,7 +134,7 @@ pub fn sign_blinded_message(private_key_buf: &[u8], message: &[u8]) -> Result<Ve
     let private_key: PrivateKey = bincode::deserialize(&private_key_buf)
         .map_err(|err| JsValue::from_str(&format!("could not deserialize private key {}", err)))?;
 
-    SigScheme::sign_without_hashing(&private_key, &message)
+    SigScheme::blind_sign(&private_key, &message)
         .map_err(|err| JsValue::from_str(&format!("could not sign message: {}", err)))
 }
 
@@ -169,7 +172,7 @@ pub fn partial_sign_blinded_message(share_buf: &[u8], message: &[u8]) -> Result<
         JsValue::from_str(&format!("could not deserialize private key share {}", err))
     })?;
 
-    SigScheme::partial_sign_without_hashing(&share, &message)
+    SigScheme::sign_blind_partial(&share, &message)
         .map_err(|err| JsValue::from_str(&format!("could not partially sign message: {}", err)))
 }
 
@@ -207,7 +210,7 @@ pub fn partial_verify_blind_signature(
     let polynomial: Poly<PublicKey> = bincode::deserialize(&polynomial_buf)
         .map_err(|err| JsValue::from_str(&format!("could not deserialize polynomial {}", err)))?;
 
-    SigScheme::partial_verify_without_hashing(&polynomial, blinded_message, sig)
+    SigScheme::verify_blind_partial(&polynomial, blinded_message, sig)
         .map_err(|err| JsValue::from_str(&format!("could not partially verify message: {}", err)))
 }
 
@@ -397,7 +400,6 @@ mod tests {
     fn signing() {
         wasm_should_blind(true);
         wasm_should_blind(false);
-
     }
 
     fn wasm_should_blind(should_blind: bool) {
@@ -413,7 +415,7 @@ mod tests {
         } else {
             (msg.clone(), vec![])
         };
-        
+
         let sign_fn = if should_blind {
             sign_blinded_message
         } else {
@@ -445,7 +447,7 @@ mod tests {
         } else {
             (msg.clone(), vec![])
         };
-        
+
         let sign_fn = if should_blind {
             partial_sign_blinded_message
         } else {
@@ -458,9 +460,12 @@ mod tests {
             partial_verify
         };
 
-        let sigs = (0..t).map(|i| sign_fn(&keys.get_share(i), &message).unwrap()).collect::<Vec<Vec<_>>>();
+        let sigs = (0..t)
+            .map(|i| sign_fn(&keys.get_share(i), &message).unwrap())
+            .collect::<Vec<Vec<_>>>();
 
-        sigs.iter().for_each(|sig| verify_fn(&keys.polynomial(), &message, &sig).unwrap());
+        sigs.iter()
+            .for_each(|sig| verify_fn(&keys.polynomial(), &message, &sig).unwrap());
 
         let concatenated = sigs.concat();
         let asig = combine(3, concatenated).unwrap();

--- a/crates/threshold-bls/src/lib.rs
+++ b/crates/threshold-bls/src/lib.rs
@@ -42,10 +42,10 @@
 //!
 //! // sign the blinded message
 //! let blinded_sig = SigScheme::blind_sign(&private, &blinded).unwrap();
-//! // verify the blinded signature with the blinded message. This can be ran
+//! // verify the blinded signature with the blinded message. This can be done
 //! // by any third party given the blinded signature & message, since they are
 //! // not private.
-//! SigScheme::blind_verify(&public,&blinded,&blinded_sig).expect("blinded signature should verify");
+//! SigScheme::blind_verify(&public, &blinded, &blinded_sig).expect("blinded signature should verify");
 //!
 //! // unblind the signature
 //! let clear_sig = SigScheme::unblind_sig(&blinding_factor, &blinded_sig).expect("unblind should not fail");

--- a/crates/threshold-bls/src/lib.rs
+++ b/crates/threshold-bls/src/lib.rs
@@ -31,20 +31,24 @@
 //! // import the instantiated scheme and the traits for signing and generating keys
 //! use threshold_bls::{
 //!     schemes::bls12_381::G1Scheme as SigScheme,
-//!     sig::{Scheme, SignatureSchemeExt, SignatureScheme, Blinder}
+//!     sig::{Scheme, SignatureScheme, BlindScheme}
 //! };
 //!
 //! let (private, public) = SigScheme::keypair(&mut rand::thread_rng());
 //! let msg = b"hello";
 //!
 //! // the blinding factor needs to be saved for unblinding later
-//! let (blinding_factor, blinded) = SigScheme::blind(&msg[..], &mut rand::thread_rng());
+//! let (blinding_factor, blinded) = SigScheme::blind_msg(&msg[..], &mut rand::thread_rng());
 //!
 //! // sign the blinded message
-//! let blinded_sig = SigScheme::sign_without_hashing(&private, &blinded).unwrap();
+//! let blinded_sig = SigScheme::blind_sign(&private, &blinded).unwrap();
+//! // verify the blinded signature with the blinded message. This can be ran
+//! // by any third party given the blinded signature & message, since they are
+//! // not private.
+//! SigScheme::blind_verify(&public,&blinded,&blinded_sig).expect("blinded signature should verify");
 //!
 //! // unblind the signature
-//! let clear_sig = SigScheme::unblind(&blinding_factor, &blinded_sig).expect("unblind should not fail");
+//! let clear_sig = SigScheme::unblind_sig(&blinding_factor, &blinded_sig).expect("unblind should not fail");
 //!
 //! SigScheme::verify(&public, &msg[..], &clear_sig).expect("signature should be verified");
 //! ```
@@ -99,7 +103,7 @@
 //! // generate the threshold sig
 //! let threshold_sig = SigScheme::aggregate(t, &partials).unwrap();
 //!
-//! <SigScheme as ThresholdScheme>::verify(
+//! SigScheme::verify(
 //!     &threshold_public_key,
 //!     &msg[..],
 //!     &threshold_sig

--- a/crates/threshold-bls/src/sig/blind.rs
+++ b/crates/threshold-bls/src/sig/blind.rs
@@ -92,10 +92,6 @@ impl<I> BlindScheme for I where I: Scheme + common::BLSScheme {
         hm.mul(private);
         Ok(bincode::serialize(&hm).expect("serialization should not fail"))
     }
-
-    fn verify(public: &Self::Public, msg: &[u8], sig: &[u8]) -> Result<(), Self::Error> {
-        I::internal_verify(public,msg,sig,true).map_err(|e| BlindError::from(e)) 
-    }
 }
 
 #[cfg(test)]
@@ -104,6 +100,7 @@ mod tests {
     use super::*;
     use crate::curve::bls12381::PairingCurve as PCurve;
     use crate::sig::bls::{G1Scheme, G2Scheme};
+    use crate::sig::SignatureScheme;
     use rand::thread_rng;
 
     #[cfg(feature = "bls12_381")]
@@ -120,7 +117,7 @@ mod tests {
 
     fn blind_test<B>()
     where
-        B: BlindScheme,
+        B: BlindScheme + SignatureScheme,
     {
         let (private, public) = B::keypair(&mut thread_rng());
         let msg = vec![1, 9, 6, 9];

--- a/crates/threshold-bls/src/sig/blind.rs
+++ b/crates/threshold-bls/src/sig/blind.rs
@@ -1,12 +1,14 @@
 use crate::group::{Element, Point, Scalar};
-use crate::sig::{BlindScheme, Blinder, SignatureScheme, SignatureSchemeExt};
+use crate::sig::bls::{common,BLSError};
+use crate::sig::{Scheme,BlindScheme, SignatureScheme, SignatureSchemeExt};
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use std::error;
 
 /// BlindError are errors which may be returned from a blind signature scheme
 #[derive(Debug, Error)]
-pub enum BlinderError {
+pub enum BlindError {
     /// InvalidToken is thrown out when the token used to unblind can not be
     /// inversed. This error should not happen if you use the Token that was
     /// returned by the blind operation.
@@ -16,6 +18,9 @@ pub enum BlinderError {
     /// Raised when (de)serialization fails
     #[error("could not deserialize: {0}")]
     BincodeError(#[from] bincode::Error),
+
+    #[error("invalid signature verification: {0}")]
+    SignatureError(#[from] BLSError),
 }
 
 /// Blinding a message before requesting a signature requires the usage of a
@@ -39,17 +44,13 @@ impl<S: Scalar> Token<S> {
     }
 }
 
-// We implement Blinder for anything that implements Signature scheme, so we also
-// enable the BlindScheme for all these, for convenience
-impl<I> BlindScheme for I where I: SignatureSchemeExt {}
-
 /// The blinder follows the protocol described
 /// in this [paper](https://eprint.iacr.org/2018/733.pdf).
-impl<I: SignatureScheme> Blinder for I {
+impl<I> BlindScheme for I where I: Scheme + common::BLSScheme {
     type Token = Token<I::Private>;
-    type Error = BlinderError;
+    type Error = BlindError;
 
-    fn blind<R: RngCore>(msg: &[u8], rng: &mut R) -> (Self::Token, Vec<u8>) {
+    fn blind_msg<R: RngCore>(msg: &[u8], rng: &mut R) -> (Self::Token, Vec<u8>) {
         let r = I::Private::rand(rng);
 
         let mut h = I::Signature::new();
@@ -63,15 +64,37 @@ impl<I: SignatureScheme> Blinder for I {
         (Token(r), serialized)
     }
 
-    fn unblind(t: &Self::Token, sigbuff: &[u8]) -> Result<Vec<u8>, Self::Error> {
+    fn unblind_sig(t: &Self::Token, sigbuff: &[u8]) -> Result<Vec<u8>, Self::Error> {
         let mut sig: I::Signature = bincode::deserialize(sigbuff)?;
 
         // r^-1 * ( r * H(m)^x) = H(m)^x
-        let ri = t.0.inverse().ok_or(BlinderError::InvalidToken)?;
+        let ri = t.0.inverse().ok_or(BlindError::InvalidToken)?;
         sig.mul(&ri);
 
         let serialized = bincode::serialize(&sig)?;
         Ok(serialized)
+    }
+    
+    fn blind_verify(public: &I::Public, blinded_msg: &[u8], blinded_sig: &[u8]) -> Result<(), Self::Error> {
+        // message point
+        let mut hm: I::Signature = bincode::deserialize(blinded_msg)?;
+        // signature point
+        let mut hs: I::Signature = bincode::deserialize(blinded_sig)?;
+        if !I::final_exp(public,&hs,&hm) {
+            return Err(BlindError::from(BLSError::InvalidSig));
+        }
+        Ok(())
+    }
+
+    fn blind_sign(private: &I::Private, blinded_msg: &[u8]) -> Result<Vec<u8>, Self::Error> {
+        // (r * H(m))^x
+        let mut hm: I::Signature = bincode::deserialize(blinded_msg)?;
+        hm.mul(private);
+        Ok(bincode::serialize(&hm).expect("serialization should not fail"))
+    }
+
+    fn verify(public: &Self::Public, msg: &[u8], sig: &[u8]) -> Result<(), Self::Error> {
+        I::internal_verify(public,msg,sig,true).map_err(|e| BlindError::from(e)) 
     }
 }
 
@@ -83,6 +106,7 @@ mod tests {
     use crate::sig::bls::{G1Scheme, G2Scheme};
     use rand::thread_rng;
 
+    #[cfg(feature = "bls12_381")]
     #[test]
     fn blind_g1() {
         blind_test::<G1Scheme<PCurve>>();
@@ -101,13 +125,13 @@ mod tests {
         let (private, public) = B::keypair(&mut thread_rng());
         let msg = vec![1, 9, 6, 9];
 
-        let (token, blinded) = B::blind(&msg, &mut thread_rng());
+        let (token, blinded) = B::blind_msg(&msg, &mut thread_rng());
 
         // signs the blinded message w/o hashing
-        let blinded_sig = B::sign_without_hashing(&private, &blinded).unwrap();
+        let blinded_sig = B::blind_sign(&private, &blinded).unwrap();
+        B::blind_verify(&public, &blinded, &blinded_sig).unwrap();
 
-        let clear_sig = B::unblind(&token, &blinded_sig).expect("unblind should go well");
-
+        let clear_sig = B::unblind_sig(&token, &blinded_sig).expect("unblind should go well");
         B::verify(&public, &msg, &clear_sig).unwrap();
     }
 }

--- a/crates/threshold-bls/src/sig/blind.rs
+++ b/crates/threshold-bls/src/sig/blind.rs
@@ -1,10 +1,9 @@
 use crate::group::{Element, Point, Scalar};
 use crate::sig::bls::{common,BLSError};
-use crate::sig::{Scheme,BlindScheme, SignatureScheme};
+use crate::sig::{Scheme,BlindScheme};
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use std::error;
 
 /// BlindError are errors which may be returned from a blind signature scheme
 #[derive(Debug, Error)]
@@ -77,9 +76,9 @@ impl<I> BlindScheme for I where I: Scheme + common::BLSScheme {
     
     fn blind_verify(public: &I::Public, blinded_msg: &[u8], blinded_sig: &[u8]) -> Result<(), Self::Error> {
         // message point
-        let mut hm: I::Signature = bincode::deserialize(blinded_msg)?;
+        let hm: I::Signature = bincode::deserialize(blinded_msg)?;
         // signature point
-        let mut hs: I::Signature = bincode::deserialize(blinded_sig)?;
+        let hs: I::Signature = bincode::deserialize(blinded_sig)?;
         if !I::final_exp(public,&hs,&hm) {
             return Err(BlindError::from(BLSError::InvalidSig));
         }

--- a/crates/threshold-bls/src/sig/blind.rs
+++ b/crates/threshold-bls/src/sig/blind.rs
@@ -1,6 +1,6 @@
 use crate::group::{Element, Point, Scalar};
-use crate::sig::bls::{common,BLSError};
-use crate::sig::{Scheme,BlindScheme};
+use crate::sig::bls::{common, BLSError};
+use crate::sig::{BlindScheme, Scheme};
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -45,7 +45,10 @@ impl<S: Scalar> Token<S> {
 
 /// The blinder follows the protocol described
 /// in this [paper](https://eprint.iacr.org/2018/733.pdf).
-impl<I> BlindScheme for I where I: Scheme + common::BLSScheme {
+impl<I> BlindScheme for I
+where
+    I: Scheme + common::BLSScheme,
+{
     type Token = Token<I::Private>;
     type Error = BlindError;
 
@@ -73,13 +76,17 @@ impl<I> BlindScheme for I where I: Scheme + common::BLSScheme {
         let serialized = bincode::serialize(&sig)?;
         Ok(serialized)
     }
-    
-    fn blind_verify(public: &I::Public, blinded_msg: &[u8], blinded_sig: &[u8]) -> Result<(), Self::Error> {
+
+    fn blind_verify(
+        public: &I::Public,
+        blinded_msg: &[u8],
+        blinded_sig: &[u8],
+    ) -> Result<(), Self::Error> {
         // message point
         let hm: I::Signature = bincode::deserialize(blinded_msg)?;
         // signature point
         let hs: I::Signature = bincode::deserialize(blinded_sig)?;
-        if !I::final_exp(public,&hs,&hm) {
+        if !I::final_exp(public, &hs, &hm) {
             return Err(BlindError::from(BLSError::InvalidSig));
         }
         Ok(())

--- a/crates/threshold-bls/src/sig/blind.rs
+++ b/crates/threshold-bls/src/sig/blind.rs
@@ -1,6 +1,6 @@
 use crate::group::{Element, Point, Scalar};
 use crate::sig::bls::{common,BLSError};
-use crate::sig::{Scheme,BlindScheme, SignatureScheme, SignatureSchemeExt};
+use crate::sig::{Scheme,BlindScheme, SignatureScheme};
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;

--- a/crates/threshold-bls/src/sig/bls.rs
+++ b/crates/threshold-bls/src/sig/bls.rs
@@ -95,26 +95,6 @@ pub mod common {
             T::internal_verify(public, msg_bytes, sig_bytes, true)
         }
     }
-
-    impl<T> SignatureSchemeExt for T
-    where
-        T: BLSScheme,
-    {
-        fn sign_without_hashing(
-            private: &Self::Private,
-            msg: &[u8],
-        ) -> Result<Vec<u8>, Self::Error> {
-            T::internal_sign(private, msg, false)
-        }
-
-        fn verify_without_hashing(
-            public: &Self::Public,
-            msg_bytes: &[u8],
-            sig_bytes: &[u8],
-        ) -> Result<(), Self::Error> {
-            T::internal_verify(public, msg_bytes, sig_bytes, false)
-        }
-    }
 }
 
 /// G1Scheme implements the BLS signature scheme with G1 as private / public

--- a/crates/threshold-bls/src/sig/bls.rs
+++ b/crates/threshold-bls/src/sig/bls.rs
@@ -1,5 +1,5 @@
 use crate::group::{Element, PairingCurve, Point};
-use crate::sig::{Scheme, SignatureScheme, SignatureSchemeExt};
+use crate::sig::{Scheme, SignatureScheme};
 use std::{fmt::Debug, marker::PhantomData};
 use thiserror::Error;
 

--- a/crates/threshold-bls/src/sig/bls.rs
+++ b/crates/threshold-bls/src/sig/bls.rs
@@ -22,7 +22,7 @@ pub enum BLSError {
 // trait into a public trait
 // see https://github.com/rust-lang/rust/issues/34537
 // XXX another way to pull it off without this hack?
-mod common {
+pub mod common {
     use super::*;
 
     /// BLSScheme is an internal trait that encompasses the common work between a

--- a/crates/threshold-bls/src/sig/mod.rs
+++ b/crates/threshold-bls/src/sig/mod.rs
@@ -4,11 +4,11 @@ pub use blind::{BlindError, Token};
 mod bls;
 pub use bls::{BLSError, G1Scheme, G2Scheme};
 
-//mod tblind;
-//pub use tblind::BlindThresholdError;
+mod tblind;
+pub use tblind::BlindThresholdError;
 
-//mod tbls;
-//pub use tbls::{Share, ThresholdError};
+mod tbls;
+pub use tbls::{Share, ThresholdError};
 
 #[allow(clippy::module_inception)]
 mod sig;

--- a/crates/threshold-bls/src/sig/mod.rs
+++ b/crates/threshold-bls/src/sig/mod.rs
@@ -1,14 +1,14 @@
 mod blind;
-pub use blind::{BlinderError, Token};
+pub use blind::{BlindError, Token};
 
 mod bls;
 pub use bls::{BLSError, G1Scheme, G2Scheme};
 
-mod tblind;
-pub use tblind::BlindThresholdError;
+//mod tblind;
+//pub use tblind::BlindThresholdError;
 
-mod tbls;
-pub use tbls::{Share, ThresholdError};
+//mod tbls;
+//pub use tbls::{Share, ThresholdError};
 
 #[allow(clippy::module_inception)]
 mod sig;

--- a/crates/threshold-bls/src/sig/sig.rs
+++ b/crates/threshold-bls/src/sig/sig.rs
@@ -75,7 +75,7 @@ pub trait SignatureScheme: Scheme {
 ///  # {
 ///  use rand::prelude::*;
 ///  use threshold_bls::{
-///     sig::{BlindScheme,SignatureScheme, Scheme, G2Scheme}, 
+///     sig::{BlindScheme,SignatureScheme, Scheme, G2Scheme},
 ///     group::{Element, Point}
 ///  };
 ///  use threshold_bls::curve::bls12381::PairingCurve as PC;
@@ -124,7 +124,11 @@ pub trait BlindScheme: Scheme {
     /// blind_verify takes the blinded message and the blinded signature and
     /// checks if the latter is correct. One must then unblind the signature so
     /// it can be verified using the regular `SignatureScheme::verify` method.
-    fn blind_verify(public: &Self::Public, blinded_msg: &[u8], blinded_sig: &[u8]) -> Result<(), Self::Error>;
+    fn blind_verify(
+        public: &Self::Public,
+        blinded_msg: &[u8],
+        blinded_sig: &[u8],
+    ) -> Result<(), Self::Error>;
 }
 
 /// Partial is simply an alias to denote a partial signature.
@@ -162,8 +166,11 @@ pub trait BlindThresholdScheme: BlindScheme {
     type Error: Error;
 
     /// sign_blind_partial partially signs a blinded message and returns a
-    /// partial signatures over this blinded message. 
-    fn sign_blind_partial(private: &Share<Self::Private>, blinded_msg: &[u8]) -> Result<Partial, <Self as BlindThresholdScheme>::Error>;
+    /// partial signatures over this blinded message.
+    fn sign_blind_partial(
+        private: &Share<Self::Private>,
+        blinded_msg: &[u8],
+    ) -> Result<Partial, <Self as BlindThresholdScheme>::Error>;
 
     /// Given the blinding factor that was used to blind a message that was blind partially
     /// signed, it will unblind it and return the cleartext signature

--- a/crates/threshold-bls/src/sig/sig.rs
+++ b/crates/threshold-bls/src/sig/sig.rs
@@ -1,4 +1,4 @@
-//pub use super::tbls::Share; // import and re-export it for easier access
+pub use super::tbls::Share; // import and re-export it for easier access
 use crate::{
     group::{Element, Point, Scalar},
     poly::Poly,
@@ -104,69 +104,54 @@ pub trait BlindScheme: Scheme {
 
     fn blind_sign(private: &Self::Private, blinded_msg: &[u8]) -> Result<Vec<u8>, Self::Error>;
 
-    fn verify(public: &Self::Public, msg: &[u8], sig: &[u8]) -> Result<(), Self::Error>;
     fn blind_verify(public: &Self::Public, blinded_msg: &[u8], blinded_sig: &[u8]) -> Result<(), Self::Error>;
 }
-/*/// Partial is simply an alias to denote a partial signature.*/
-//pub type Partial = Vec<u8>;
+/// Partial is simply an alias to denote a partial signature.
+pub type Partial = Vec<u8>;
 
-///// ThresholdScheme is a threshold-based `t-n` signature scheme. The security of
-///// such a scheme means at least `t` participants are required produce a "partial
-///// signature" to then produce a regular signature.
-///// The `dkg-core` module allows participants to create a distributed private/public key
-/*/// that can be used with implementations `ThresholdScheme`.*/
-/*pub trait ThresholdScheme: Scheme {*/
-    ///// Error produced when partially signing, aggregating or verifying
-    //type Error: Error;
+/// ThresholdScheme is a threshold-based `t-n` signature scheme. The security of
+/// such a scheme means at least `t` participants are required produce a "partial
+/// signature" to then produce a regular signature.
+/// The `dkg-core` module allows participants to create a distributed private/public key
+/// that can be used with implementations `ThresholdScheme`.
+pub trait ThresholdScheme: Scheme {
+    /// Error produced when partially signing, aggregating or verifying
+    type Error: Error;
 
-    ///// Partially signs a message with a share of the private key
-    //fn partial_sign(private: &Share<Self::Private>, msg: &[u8]) -> Result<Partial, Self::Error>;
+    /// Partially signs a message with a share of the private key
+    fn partial_sign(private: &Share<Self::Private>, msg: &[u8]) -> Result<Partial, Self::Error>;
 
-    ///// Verifies a partial signature on a message against the public polynomial
-    //fn partial_verify(
-        //public: &Poly<Self::Public>,
-        //msg: &[u8],
-        //partial: &[u8],
-    //) -> Result<(), Self::Error>;
+    /// Verifies a partial signature on a message against the public polynomial
+    fn partial_verify(
+        public: &Poly<Self::Public>,
+        msg: &[u8],
+        partial: &[u8],
+    ) -> Result<(), Self::Error>;
 
-    ///// Aggregates all partials signature together. Note that this method does
-    ///// not verify if the partial signatures are correct or not; it only
-    ///// aggregates them.
-    //fn aggregate(threshold: usize, partials: &[Partial]) -> Result<Vec<u8>, Self::Error>;
+    /// Aggregates all partials signature together. Note that this method does
+    /// not verify if the partial signatures are correct or not; it only
+    /// aggregates them.
+    fn aggregate(threshold: usize, partials: &[Partial]) -> Result<Vec<u8>, Self::Error>;
+}
 
-    ///// Verifies a threshold signature on a message against the public key which corresponds
-    ///// to the public polynomial of the shares that produced the partial signatures
-    //fn verify(public: &Self::Public, msg: &[u8], sig: &[u8]) -> Result<(), Self::Error>;
-//}
+/// BlindThreshold is ThresholdScheme that allows to verify a partially blinded
+/// signature as well blinded message, to aggregate them into one blinded signature
+/// such that it can be unblinded after and verified as a regular signature.
+pub trait BlindThresholdScheme: BlindScheme {
+    type Error: Error;
 
-///// Extension trait over `ThresholdScheme` which provides partial signing & verification methods
-///// which do not hash the message.
-//pub trait ThresholdSchemeExt: ThresholdScheme {
-    ///// Partially signs a message with a share of the private key **without hashing the message**
-    //fn partial_sign_without_hashing(
-        //private: &Share<Self::Private>,
-        //msg: &[u8],
-    //) -> Result<Partial, Self::Error>;
+    fn blind_partial_sign(private: &Share<Self::Private>, msg: &[u8]) -> Result<Partial, <Self as BlindThresholdScheme>::Error>;
 
-    ///// Verifies a partial signature on a message against the public polynomial **without hashing
-    ///// the message**
-    //fn partial_verify_without_hashing(
-        //public: &Poly<Self::Public>,
-        //msg: &[u8],
-        //partial: &[u8],
-    //) -> Result<(), Self::Error>;
-//}
+    /// Given the blinding factor that was used to blind a message that was blind partially
+    /// signed, it will unblind it and return the cleartext signature
+    fn unblind_partial_sig(
+        t: &Self::Token,
+        partial: &[u8],
+    ) -> Result<Partial, <Self as BlindThresholdScheme>::Error>;
 
-///// BlindThreshold is ThresholdScheme that allows to verify a partially blinded
-///// signature as well blinded message, to aggregate them into one blinded signature
-///// such that it can be unblinded after and verified as a regular signature.
-//pub trait BlindThresholdScheme: ThresholdSchemeExt + Blinder {
-    //type Error: Error;
-
-    ///// Given the blinding factor that was used to blind a message that was blind partially
-    ///// signed, it will unblind it and return the cleartext signature
-    //fn unblind_partial(
-        //t: &Self::Token,
-        //partial: &[u8],
-    //) -> Result<Partial, <Self as BlindThresholdScheme>::Error>;
-/*}*/
+    fn blind_partial_verify(
+        public: &Poly<Self::Public>,
+        blind_msg: &[u8],
+        blind_partial: &[u8],
+    ) -> Result<(), <Self as BlindThresholdScheme>::Error>;
+}

--- a/crates/threshold-bls/src/sig/sig.rs
+++ b/crates/threshold-bls/src/sig/sig.rs
@@ -66,7 +66,7 @@ pub trait SignatureScheme: Scheme {
 }
 
 /// BlindScheme is a signature scheme where the message can be blinded before
-/// signature so the signer does not know the real message. The signature can
+/// signing so the signer does not know the real message. The signature can
 /// later be "unblinded" as to reveal a valid signature over the initial
 /// message.
 ///
@@ -85,13 +85,14 @@ pub trait SignatureScheme: Scheme {
 ///  // we first blind the message so the signers don't know the real underlying
 ///  // message they are signing.
 ///  let (token, blinded_msg) = G2Scheme::<PC>::blind_msg(&msg,&mut thread_rng());
-///  // this method is called on the signers, that sign blindly.
+///  // this method is called by the signers, that sign blindly.
 ///  let blinded_sig = G2Scheme::<PC>::blind_sign(&private,&blinded_msg).unwrap();
 ///  // this method can be called by a third party that is able to verify if a
 ///  // blinded signature is a a valid one even without having access to the
 ///  // clear message.
 ///  G2Scheme::<PC>::blind_verify(&public,&blinded_msg,&blinded_sig)
 ///        .expect("blinded signatures should be correct");
+
 ///  // the owner of the message can then unblind the signature to reveal a
 ///  // regular signature that can be verified using the regular method of the
 ///  // SignatureScheme.
@@ -122,7 +123,7 @@ pub trait BlindScheme: Scheme {
     fn blind_sign(private: &Self::Private, blinded_msg: &[u8]) -> Result<Vec<u8>, Self::Error>;
 
     /// blind_verify takes the blinded message and the blinded signature and
-    /// checks if the latter is correct. One must then unblind the signature so
+    /// checks if the latter is a valid signature by the provided public key. One must then unblind the signature so
     /// it can be verified using the regular `SignatureScheme::verify` method.
     fn blind_verify(
         public: &Self::Public,
@@ -166,7 +167,7 @@ pub trait BlindThresholdScheme: BlindScheme {
     type Error: Error;
 
     /// sign_blind_partial partially signs a blinded message and returns a
-    /// partial signatures over this blinded message.
+    /// partial blind signature over it.
     fn sign_blind_partial(
         private: &Share<Self::Private>,
         blinded_msg: &[u8],
@@ -179,7 +180,7 @@ pub trait BlindThresholdScheme: BlindScheme {
         partial: &[u8],
     ) -> Result<Partial, <Self as BlindThresholdScheme>::Error>;
 
-    /// verify_blind_partial checks if a given blinded partial signatures is
+    /// verify_blind_partial checks if a given blinded partial signature is
     /// correct given the blinded message. This can be called by any third party
     /// given the two parameters which are not private (since they are blinded).
     fn verify_blind_partial(

--- a/crates/threshold-bls/src/sig/sig.rs
+++ b/crates/threshold-bls/src/sig/sig.rs
@@ -1,4 +1,4 @@
-pub use super::tbls::Share; // import and re-export it for easier access
+//pub use super::tbls::Share; // import and re-export it for easier access
 use crate::{
     group::{Element, Point, Scalar},
     poly::Poly,
@@ -83,10 +83,11 @@ pub trait SignatureSchemeExt: SignatureScheme {
     ) -> Result<(), Self::Error>;
 }
 
-/// Blinder holds the functionality of blinding and unblinding a message. It is
-/// not to be used alone but in combination with a signature scheme or a
-/// threshold scheme.
-pub trait Blinder {
+/// BlindScheme is a signature scheme where the message can be blinded before
+/// signature so the signer does not know the real message. The signature can
+/// later be "unblinded" as to reveal a valid signature over the initial
+/// message.
+pub trait BlindScheme: Scheme {
     /// The blinding factor which will be used to unblind the message
     type Token: Serialize + DeserializeOwned;
 
@@ -95,79 +96,77 @@ pub trait Blinder {
 
     /// Blinds the provided message using randomness from the provided RNG and returns
     /// the blinding factor and the blinded message.
-    fn blind<R: RngCore>(msg: &[u8], rng: &mut R) -> (Self::Token, Vec<u8>);
+    fn blind_msg<R: RngCore>(msg: &[u8], rng: &mut R) -> (Self::Token, Vec<u8>);
 
     /// Given the blinding factor that was used to blind the provided message, it will
     /// unblind it and return the cleartext message
-    fn unblind(t: &Self::Token, blinded_message: &[u8]) -> Result<Vec<u8>, Self::Error>;
-}
+    fn unblind_sig(t: &Self::Token, blinded_message: &[u8]) -> Result<Vec<u8>, Self::Error>;
 
-/// BlindScheme is a signature scheme where the message can be blinded before
-/// signature so the signer does not know the real message. The signature can
-/// later be "unblinded" as to reveal a valid signature over the initial
-/// message.
-pub trait BlindScheme: SignatureSchemeExt + Blinder {}
+    fn blind_sign(private: &Self::Private, blinded_msg: &[u8]) -> Result<Vec<u8>, Self::Error>;
 
-/// Partial is simply an alias to denote a partial signature.
-pub type Partial = Vec<u8>;
-
-/// ThresholdScheme is a threshold-based `t-n` signature scheme. The security of
-/// such a scheme means at least `t` participants are required produce a "partial
-/// signature" to then produce a regular signature.
-/// The `dkg-core` module allows participants to create a distributed private/public key
-/// that can be used with implementations `ThresholdScheme`.
-pub trait ThresholdScheme: Scheme {
-    /// Error produced when partially signing, aggregating or verifying
-    type Error: Error;
-
-    /// Partially signs a message with a share of the private key
-    fn partial_sign(private: &Share<Self::Private>, msg: &[u8]) -> Result<Partial, Self::Error>;
-
-    /// Verifies a partial signature on a message against the public polynomial
-    fn partial_verify(
-        public: &Poly<Self::Public>,
-        msg: &[u8],
-        partial: &[u8],
-    ) -> Result<(), Self::Error>;
-
-    /// Aggregates all partials signature together. Note that this method does
-    /// not verify if the partial signatures are correct or not; it only
-    /// aggregates them.
-    fn aggregate(threshold: usize, partials: &[Partial]) -> Result<Vec<u8>, Self::Error>;
-
-    /// Verifies a threshold signature on a message against the public key which corresponds
-    /// to the public polynomial of the shares that produced the partial signatures
     fn verify(public: &Self::Public, msg: &[u8], sig: &[u8]) -> Result<(), Self::Error>;
+    fn blind_verify(public: &Self::Public, blinded_msg: &[u8], blinded_sig: &[u8]) -> Result<(), Self::Error>;
 }
+/*/// Partial is simply an alias to denote a partial signature.*/
+//pub type Partial = Vec<u8>;
 
-/// Extension trait over `ThresholdScheme` which provides partial signing & verification methods
-/// which do not hash the message.
-pub trait ThresholdSchemeExt: ThresholdScheme {
-    /// Partially signs a message with a share of the private key **without hashing the message**
-    fn partial_sign_without_hashing(
-        private: &Share<Self::Private>,
-        msg: &[u8],
-    ) -> Result<Partial, Self::Error>;
+///// ThresholdScheme is a threshold-based `t-n` signature scheme. The security of
+///// such a scheme means at least `t` participants are required produce a "partial
+///// signature" to then produce a regular signature.
+///// The `dkg-core` module allows participants to create a distributed private/public key
+/*/// that can be used with implementations `ThresholdScheme`.*/
+/*pub trait ThresholdScheme: Scheme {*/
+    ///// Error produced when partially signing, aggregating or verifying
+    //type Error: Error;
 
-    /// Verifies a partial signature on a message against the public polynomial **without hashing
-    /// the message**
-    fn partial_verify_without_hashing(
-        public: &Poly<Self::Public>,
-        msg: &[u8],
-        partial: &[u8],
-    ) -> Result<(), Self::Error>;
-}
+    ///// Partially signs a message with a share of the private key
+    //fn partial_sign(private: &Share<Self::Private>, msg: &[u8]) -> Result<Partial, Self::Error>;
 
-/// BlindThreshold is ThresholdScheme that allows to verify a partially blinded
-/// signature as well blinded message, to aggregate them into one blinded signature
-/// such that it can be unblinded after and verified as a regular signature.
-pub trait BlindThresholdScheme: ThresholdSchemeExt + Blinder {
-    type Error: Error;
+    ///// Verifies a partial signature on a message against the public polynomial
+    //fn partial_verify(
+        //public: &Poly<Self::Public>,
+        //msg: &[u8],
+        //partial: &[u8],
+    //) -> Result<(), Self::Error>;
 
-    /// Given the blinding factor that was used to blind a message that was blind partially
-    /// signed, it will unblind it and return the cleartext signature
-    fn unblind_partial(
-        t: &Self::Token,
-        partial: &[u8],
-    ) -> Result<Partial, <Self as BlindThresholdScheme>::Error>;
-}
+    ///// Aggregates all partials signature together. Note that this method does
+    ///// not verify if the partial signatures are correct or not; it only
+    ///// aggregates them.
+    //fn aggregate(threshold: usize, partials: &[Partial]) -> Result<Vec<u8>, Self::Error>;
+
+    ///// Verifies a threshold signature on a message against the public key which corresponds
+    ///// to the public polynomial of the shares that produced the partial signatures
+    //fn verify(public: &Self::Public, msg: &[u8], sig: &[u8]) -> Result<(), Self::Error>;
+//}
+
+///// Extension trait over `ThresholdScheme` which provides partial signing & verification methods
+///// which do not hash the message.
+//pub trait ThresholdSchemeExt: ThresholdScheme {
+    ///// Partially signs a message with a share of the private key **without hashing the message**
+    //fn partial_sign_without_hashing(
+        //private: &Share<Self::Private>,
+        //msg: &[u8],
+    //) -> Result<Partial, Self::Error>;
+
+    ///// Verifies a partial signature on a message against the public polynomial **without hashing
+    ///// the message**
+    //fn partial_verify_without_hashing(
+        //public: &Poly<Self::Public>,
+        //msg: &[u8],
+        //partial: &[u8],
+    //) -> Result<(), Self::Error>;
+//}
+
+///// BlindThreshold is ThresholdScheme that allows to verify a partially blinded
+///// signature as well blinded message, to aggregate them into one blinded signature
+///// such that it can be unblinded after and verified as a regular signature.
+//pub trait BlindThresholdScheme: ThresholdSchemeExt + Blinder {
+    //type Error: Error;
+
+    ///// Given the blinding factor that was used to blind a message that was blind partially
+    ///// signed, it will unblind it and return the cleartext signature
+    //fn unblind_partial(
+        //t: &Self::Token,
+        //partial: &[u8],
+    //) -> Result<Partial, <Self as BlindThresholdScheme>::Error>;
+/*}*/

--- a/crates/threshold-bls/src/sig/sig.rs
+++ b/crates/threshold-bls/src/sig/sig.rs
@@ -140,7 +140,7 @@ pub trait ThresholdScheme: Scheme {
 pub trait BlindThresholdScheme: BlindScheme {
     type Error: Error;
 
-    fn blind_partial_sign(private: &Share<Self::Private>, msg: &[u8]) -> Result<Partial, <Self as BlindThresholdScheme>::Error>;
+    fn sign_blind_partial(private: &Share<Self::Private>, msg: &[u8]) -> Result<Partial, <Self as BlindThresholdScheme>::Error>;
 
     /// Given the blinding factor that was used to blind a message that was blind partially
     /// signed, it will unblind it and return the cleartext signature
@@ -149,7 +149,7 @@ pub trait BlindThresholdScheme: BlindScheme {
         partial: &[u8],
     ) -> Result<Partial, <Self as BlindThresholdScheme>::Error>;
 
-    fn blind_partial_verify(
+    fn verify_blind_partial(
         public: &Poly<Self::Public>,
         blind_msg: &[u8],
         blind_partial: &[u8],

--- a/crates/threshold-bls/src/sig/tblind.rs
+++ b/crates/threshold-bls/src/sig/tblind.rs
@@ -96,29 +96,28 @@ mod tests {
     #[cfg(feature = "bls12_377")]
     #[test]
     fn tblind_g1_zexe_unblind() {
-        aggregate_partially_unblinded::<G1Scheme<Zexe>>();
+        tblind_test::<G1Scheme<Zexe>>();
     }
 
     #[cfg(feature = "bls12_377")]
     #[test]
     fn tblind_g2_zexe_unblind() {
-        aggregate_partially_unblinded::<G2Scheme<Zexe>>();
+        tblind_test::<G2Scheme<Zexe>>();
     }
 
     #[cfg(feature = "bls12_381")]
     #[test]
     fn tblind_g1_bellman_unblind() {
-        aggregate_partially_unblinded::<G1Scheme<PCurve>>();
+        tblind_test::<G1Scheme<PCurve>>();
     }
 
     #[cfg(feature = "bls12_381")]
     #[test]
     fn tblind_g2_bellman_unblind() {
-        aggregate_partially_unblinded::<G2Scheme<PCurve>>();
-        //aggregate_partially_blinded::<G2Scheme<PCurve>>();
+        tblind_test::<G2Scheme<PCurve>>();
     }
 
-    fn aggregate_partially_unblinded<B>()
+    fn tblind_test<B>()
     where
         B: BlindThresholdScheme + SignatureScheme + ThresholdScheme,
     {
@@ -150,15 +149,15 @@ mod tests {
             .map(|p| B::unblind_partial_sig(&token, p).unwrap())
             .collect();
 
-        // aggregate
+        // aggregate & verify the unblinded partials
         let final_sig1 = B::aggregate(thr, &unblindeds_partials).unwrap();
-
         B::verify(&public.public_key(), &msg, &final_sig1).unwrap();
 
         // Another method is to aggregate the blinded partials directly. This
         // can be done by a third party
         let blinded_final = B::aggregate(thr, &partials).unwrap();
-        // unblind the final signature
+
+        // unblind the aggregated signature
         let final_sig2 = B::unblind_sig(&token, &blinded_final).unwrap();
 
         // verify the final signature

--- a/crates/threshold-bls/src/sig/tblind.rs
+++ b/crates/threshold-bls/src/sig/tblind.rs
@@ -1,6 +1,6 @@
-use crate::poly::{Poly, Eval};
-use crate::sig::{BlindThresholdScheme, ThresholdScheme,BlindScheme, Partial};
+use crate::poly::{Eval, Poly};
 use crate::sig::tbls::Share;
+use crate::sig::{BlindScheme, BlindThresholdScheme, Partial, ThresholdScheme};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -22,8 +22,12 @@ where
 {
     type Error = BlindThresholdError<<T as BlindScheme>::Error>;
 
-    fn sign_blind_partial(private: &Share<Self::Private>, blinded_msg: &[u8]) -> Result<Partial, <Self as BlindThresholdScheme>::Error> {
-        let sig = Self::blind_sign(&private.private,blinded_msg).map_err(BlindThresholdError::BlindError)?;
+    fn sign_blind_partial(
+        private: &Share<Self::Private>,
+        blinded_msg: &[u8],
+    ) -> Result<Partial, <Self as BlindThresholdScheme>::Error> {
+        let sig = Self::blind_sign(&private.private, blinded_msg)
+            .map_err(BlindThresholdError::BlindError)?;
         let partial = Eval {
             value: sig,
             index: private.index,
@@ -54,7 +58,8 @@ where
     ) -> Result<(), <Self as BlindThresholdScheme>::Error> {
         let blinded_partial: Eval<Vec<u8>> = bincode::deserialize(blind_partial)?;
         let public_i = public.eval(blinded_partial.index);
-        Self::blind_verify(&public_i.value,blind_msg,&blinded_partial.value).map_err(BlindThresholdError::BlindError)
+        Self::blind_verify(&public_i.value, blind_msg, &blinded_partial.value)
+            .map_err(BlindThresholdError::BlindError)
     }
 }
 
@@ -132,10 +137,12 @@ mod tests {
             .collect();
 
         // verify if each blind partial signatures is correct
-        assert_eq!(false,partials
-            .iter()
-            .any(|p| B::verify_blind_partial(&public, &blinded,p).is_err()));
-
+        assert_eq!(
+            false,
+            partials
+                .iter()
+                .any(|p| B::verify_blind_partial(&public, &blinded, p).is_err())
+        );
 
         // unblind each partial sig
         let unblindeds: Vec<_> = partials
@@ -168,19 +175,19 @@ mod tests {
             .collect();
 
         // verify if each blind partial signatures is correct
-        assert_eq!(false,partials
-            .iter()
-            .any(|p| B::verify_blind_partial(&public, &blinded,p).is_err()));
-
+        assert_eq!(
+            false,
+            partials
+                .iter()
+                .any(|p| B::verify_blind_partial(&public, &blinded, p).is_err())
+        );
 
         // aggregate blinded partials
         let blinded_final = B::aggregate(thr, &partials).unwrap();
         // unblind the final signature
-        let final_sig = B::unblind_sig(&token,&blinded_final).unwrap();
+        let final_sig = B::unblind_sig(&token, &blinded_final).unwrap();
 
         // verify the final signature
         B::verify(&public.public_key(), &msg, &final_sig).unwrap();
     }
-
 }
-

--- a/crates/threshold-bls/src/sig/tbls.rs
+++ b/crates/threshold-bls/src/sig/tbls.rs
@@ -2,10 +2,9 @@
 //! [`SignatureScheme`](../trait.SignatureScheme.html)
 use crate::poly::{Eval, Idx, Poly, PolyError};
 use crate::sig::{
-    Partial, SignatureScheme, SignatureSchemeExt, ThresholdScheme};
+    Partial, SignatureScheme, ThresholdScheme};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use std::error;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 /// A private share which is part of the threshold signing key

--- a/crates/threshold-bls/src/sig/tbls.rs
+++ b/crates/threshold-bls/src/sig/tbls.rs
@@ -1,8 +1,7 @@
 //! Threshold Signatures implementation for any type which implements
 //! [`SignatureScheme`](../trait.SignatureScheme.html)
 use crate::poly::{Eval, Idx, Poly, PolyError};
-use crate::sig::{
-    Partial, SignatureScheme, ThresholdScheme};
+use crate::sig::{Partial, SignatureScheme, ThresholdScheme};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 


### PR DESCRIPTION
This PR brings a modified API with two goals in mind:
* Only expose operations useful for users, allowing them to perform the different schemes of tblind
* Continuing on the path of the philosophy "import the trait to use the functionality".

The second rule makes the trait `BlindScheme` `ThresholdScheme` not having a `verify()` function anymore. The function is available when you import `SignatureScheme`, because verify takes a single regular signature and a single regular public key and a non-blinded message, as a `SignatureScheme`.

The first rule made me rethink these interfaces and I merged `Blinder` and `BlindScheme` into one trait. As well, the `BlindThresholdScheme` only brings out the necessary operations, and can now verify  a blinded signature as well.