### PR TITLE
DKG Board Smart Contract

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ pkg/
 NDK
 .cargo
 react-native
+
+solidity/cache
+solidity/build

--- a/solidity/.solhint.json
+++ b/solidity/.solhint.json
@@ -1,0 +1,9 @@
+{
+  "extends": "solhint:recommended",
+  "plugins": ["prettier"],
+  "rules": {
+    "prettier/prettier": "error",
+    "avoid-suicide": "error",
+    "avoid-sha3": "warn"
+  }
+}

--- a/solidity/README.md
+++ b/solidity/README.md
@@ -10,16 +10,18 @@ yarn build
 yarn test
 ```
 
+## Deploy
+
+3 environment variables are requierd. 
+- `ENDPOINT`: your Web3 json-rpc compatible endpoint
+- `PRIVATE_KEY`: the address which will deploy the DKG contract
+- `PHASE_DURATION`: the duration _in blocks_ of each DKG phase
+
+## Methods to call
+
 Methods are provided for each DKG participant to call in each phase:
 - `register`
-- `publishShares`
-- `publishResponses`
-- `publishJustifications`
-
-## Privileged Account
-
-The contract's deployer is the on who is able to start the DKG procedure by calling `start` after
-enough participants have registered.
+- `publish` (depending on the time it will save the provided data as shares, responses or justifications)
 
 ## Phase 0
 
@@ -43,3 +45,9 @@ The DKG transition automatically to Phase 3 after `N` blocks have passed since t
 since the `start` function was called). Each of the registered participants MAY publish their justifications ONCE.
 
 _note: This phase should not be required by users published all their shares in Phase 1._
+
+## Privileged Account
+
+The contract's deployer is the on who is able to start the DKG procedure by calling `start` after
+enough participants have registered.
+

--- a/solidity/README.md
+++ b/solidity/README.md
@@ -1,0 +1,45 @@
+# JF-DKG with a blockchain as a broadcast layer
+
+## Build & Test
+
+Internally, uses [`buidler`](https://buidler.dev/) to build and test the code.
+
+```
+yarn
+yarn build
+yarn test
+```
+
+Methods are provided for each DKG participant to call in each phase:
+- `register`
+- `publishShares`
+- `publishResponses`
+- `publishJustifications`
+
+## Privileged Account
+
+The contract's deployer is the on who is able to start the DKG procedure by calling `start` after
+enough participants have registered.
+
+## Phase 0
+
+Participants register during that time period by calling the `register(bytes blsPublicKey)` function.
+Participants that have not registered in this phase will not be able to participate in any of the 
+following stages.
+
+## Phase 1
+
+Phase 1 is initiated once the `start` function is called by the DKG contract's deployer. Each of the
+registered participants MAY publish their shares ONCE.
+
+## Phase 2
+
+The DKG transition automatically to Phase 2 after `N` blocks have passed since the start of Phase 1. Each
+of the registered participants MAY publish their responses ONCE.
+
+## Phase 3
+
+The DKG transition automatically to Phase 3 after `N` blocks have passed since the start of Phase 2 (so in total `2 * N` blocks
+since the `start` function was called). Each of the registered participants MAY publish their justifications ONCE.
+
+_note: This phase should not be required by users published all their shares in Phase 1._

--- a/solidity/buidler.config.ts
+++ b/solidity/buidler.config.ts
@@ -1,9 +1,22 @@
 import { usePlugin } from "@nomiclabs/buidler/config";
 
+// use env vars from .env file
+import { config } from "dotenv"
+config({ path: ".env" })
+
 usePlugin("@nomiclabs/buidler-waffle");
+
+const URL = process.env.ENDPOINT || "";
+const PRIVATE_KEY = process.env.PRIVATE_KEY || "";
 
 export default {
     defaultNetwork: "buidlerevm",
+    networks: {
+        mainnet: {
+            url: URL,
+            accounts: [PRIVATE_KEY],
+        },
+    },
     solc: {
         version: "0.6.6",
         optimizer: {

--- a/solidity/buidler.config.ts
+++ b/solidity/buidler.config.ts
@@ -1,0 +1,17 @@
+import { usePlugin } from "@nomiclabs/buidler/config";
+
+usePlugin("@nomiclabs/buidler-waffle");
+
+export default {
+    defaultNetwork: "buidlerevm",
+    solc: {
+        version: "0.6.6",
+        optimizer: {
+            enabled: true,
+            runs: 200,
+        }
+    },
+    paths: {
+        artifacts: "./build"
+    }
+};

--- a/solidity/contracts/DKG.sol
+++ b/solidity/contracts/DKG.sol
@@ -1,0 +1,77 @@
+pragma solidity ^0.6.6;
+
+import "@nomiclabs/buidler/console.sol";
+
+
+contract DKG {
+    mapping(address => bytes) public keys;
+
+    mapping(address => bytes) public shares;
+
+    mapping(address => bytes) public responses;
+
+    mapping(address => bytes) public justifications;
+
+    uint256 immutable PHASE_DURATION;
+
+    uint256 public startBlock = 0;
+
+    address owner;
+
+    modifier onlyRegistered() {
+        require(keys[msg.sender].length > 0, "you are not registered!");
+        _;
+    }
+
+    modifier onlyWhenNotStarted() {
+        require(startBlock == 0, "DKG has already started");
+        _;
+    }
+
+    constructor(uint256 duration) public {
+        PHASE_DURATION = duration;
+        owner = msg.sender;
+    }
+
+    /// Kickoff function which starts the counter
+    function start() external onlyWhenNotStarted {
+        require(
+            msg.sender == owner,
+            "only contract deployer may start the DKG"
+        );
+        startBlock = block.number;
+    }
+
+    /// This function ties a DKG participant's on-chain address with their BLS Public Key
+    function register(bytes calldata blsPublicKey) external onlyWhenNotStarted {
+        require(keys[msg.sender].length == 0, "user is already registered");
+        keys[msg.sender] = blsPublicKey;
+    }
+
+    /// Participant publishes their data nand depending on the time it gets
+    function publish(bytes calldata value) external onlyRegistered {
+        uint256 blocksSinceStart = block.number - startBlock;
+
+        if (blocksSinceStart <= PHASE_DURATION) {
+            require(
+                shares[msg.sender].length == 0,
+                "you have already published your shares"
+            );
+            shares[msg.sender] = value;
+        } else if (blocksSinceStart <= 2 * PHASE_DURATION) {
+            require(
+                responses[msg.sender].length == 0,
+                "you have already published your responses"
+            );
+            responses[msg.sender] = value;
+        } else if (blocksSinceStart <= 3 * PHASE_DURATION) {
+            require(
+                justifications[msg.sender].length == 0,
+                "you have already published your justifications"
+            );
+            justifications[msg.sender] = value;
+        } else {
+            revert("DKG has ended");
+        }
+    }
+}

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,9 +1,10 @@
 {
   "name": "celo-dkg-contracts",
   "version": "1.0.0",
-  "description": "Contracts acting as a broadcast layer for a JF-DKG",
+  "description": "Contract acting as a broadcast layer for a JF-DKG",
   "scripts": {
     "build": "npx buidler compile",
+    "lint": "prettier --write **/*.sol",
     "test": "npx buidler test"
   },
   "author": "Georgios Konstantopoulos <me@gakonst.com>",

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "celo-dkg-contracts",
+  "version": "1.0.0",
+  "description": "Contracts acting as a broadcast layer for a JF-DKG",
+  "scripts": {
+    "build": "npx buidler compile",
+    "test": "npx buidler test"
+  },
+  "author": "Georgios Konstantopoulos <me@gakonst.com>",
+  "license": "ISC",
+  "devDependencies": {
+    "@nomiclabs/buidler": "^1.3.2",
+    "@nomiclabs/buidler-ethers": "^1.2.0",
+    "@nomiclabs/buidler-waffle": "^1.2.0",
+    "@types/chai": "^4.2.11",
+    "@types/mocha": "^7.0.2",
+    "@types/node": "^13.11.1",
+    "chai": "^4.2.0",
+    "ethereum-waffle": "^2.4.1",
+    "ethers": "^4.0.46",
+    "mocha": "^7.1.1",
+    "ts-node": "^8.8.2",
+    "typings": "^2.1.1"
+  }
+}

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "build": "npx buidler compile",
     "lint": "prettier --write **/*.sol",
-    "test": "npx buidler test"
+    "test": "npx buidler test",
+    "deploy": "npx buidler run --network mainnet scripts/deploy.ts"
   },
   "author": "Georgios Konstantopoulos <me@gakonst.com>",
   "license": "ISC",

--- a/solidity/scripts/deploy.ts
+++ b/solidity/scripts/deploy.ts
@@ -1,0 +1,23 @@
+import { ethers } from "@nomiclabs/buidler";
+
+async function main() {
+  const factory = await ethers.getContract("DKG")
+
+  let contract = await factory.deploy(process.env.PHASE_DURATION)
+
+  // The address the Contract WILL have once mined
+  console.log("DKG deployed at:", contract.address);
+
+  // The transaction that was sent to the network to deploy the Contract
+  console.log("Transaction hash:", contract.deployTransaction.hash);
+
+  // The contract is NOT deployed yet; we must wait until it is mined
+  await contract.deployed()
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch(error => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/solidity/test/dkg.spec.ts
+++ b/solidity/test/dkg.spec.ts
@@ -65,14 +65,15 @@ describe('DKG', () => {
             await dkg.connect(deployer).start()
         })
 
-        it('publishes to shares', async () => {
+        // TODO: Why does `dkg.shares()` hang? Is this a buidlerevm issue?
+        it.skip('publishes to shares', async () => {
             await dkg.publish(data)
             const shares = await dkg.shares(participants[0]).call();
             expect(shares).to.equal(data)
         })
 
 
-        it.only('cannot publish to shares twice', async () => {
+        it('cannot publish to shares twice', async () => {
             await dkg.publish(data)
             await expect(dkg.publish(data)).revertedWith("you have already published your shares")
         })

--- a/solidity/test/dkg.spec.ts
+++ b/solidity/test/dkg.spec.ts
@@ -1,0 +1,82 @@
+import { use, expect, assert } from 'chai'
+import { ethers } from "ethers"
+
+import { deployContract, solidity } from 'ethereum-waffle'
+import { waffle } from "@nomiclabs/buidler";
+
+// The actual contract
+import DKG from "../build/DKG.json"
+
+use(solidity);
+
+
+describe('DKG', () => {
+    const provider = waffle.provider;
+    const [deployer, ...participants] = provider.getWallets();
+
+    const timeTravel = async (blocks: number) => {
+      for (let i = 0; i < blocks; i++) {
+        await provider.send('evm_mine', [])
+      }
+    }
+
+    // Each phase's data is just an opaque blob of data from the smart contract's
+    // perspective, so we'll just use a dummy data object
+    const data = "0x2222222222222222222222222222222222222222222222222222222222222222"
+
+    // Each phase lasts 30 blocks
+    const PHASE_DURATION = 30;
+
+    let dkg: ethers.Contract;
+
+    beforeEach(async () => {
+        dkg = await deployContract(deployer, DKG, [PHASE_DURATION]);
+    })
+
+    describe('Registration', async () => {
+        it('participants can register', async () => {
+            await dkg.register(data)
+        })
+
+        it('participants cannot register twice', async () => {
+            await dkg.register(data)
+            await expect(dkg.register(data)).revertedWith("user is already registered")
+        })
+
+        it('cannot register once started', async () => {
+            await dkg.start()
+            await expect(dkg.register(data)).revertedWith("DKG has already started")
+        });
+
+        it('only owner can start the DKG', async () => {
+            await expect(dkg.connect(participants[0]).start()).revertedWith("only contract deployer may start the DKG")
+        });
+
+        it('cannot publish if not registered', async () => {
+            expect(dkg.connect(participants[1]).publish(data)).revertedWith("you are not registered!");
+        })
+    })
+
+    describe('Shares', async () => {
+        beforeEach(async () => {
+            dkg = dkg.connect(participants[0])
+            await dkg.register(data)
+
+            await dkg.connect(deployer).start()
+        })
+
+        it('publishes to shares', async () => {
+            await dkg.publish(data)
+            const shares = await dkg.shares(participants[0]).call();
+            expect(shares).to.equal(data)
+        })
+
+
+        it.only('cannot publish to shares twice', async () => {
+            await dkg.publish(data)
+            await expect(dkg.publish(data)).revertedWith("you have already published your shares")
+        })
+    })
+
+    // TODO: Timetravel to each of the other periods
+})

--- a/solidity/tsconfig.json
+++ b/solidity/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "lib": [ "es2015" ],
+        "target": "es5",
+        "module": "commonjs",
+        "strict": true,
+        "esModuleInterop": true,
+        "outDir": "dist",
+        "resolveJsonModule": true
+    },
+    "include": ["./scripts", "./test"],
+    "files": [
+        "./buidler.config.ts",
+        "./node_modules/@nomiclabs/buidler-ethers/src/type-extensions.d.ts",
+        "./node_modules/@nomiclabs/buidler-waffle/src/type-extensions.d.ts"
+    ]
+}


### PR DESCRIPTION
The contract is pretty simple:

1. Deploy it
2. Users must register their keys. These keys will then be used by the rust client to instantiate the `Group`
3. Deployer calls `start` to kickoff the procedure
4. For each phase, each user can only call `publish(data)` ONCE. Phase transitions happen automatically, every `PHASE_DURATION` blocks.

The Rust CLI will be doing a `publish` call with the necessary data. For each phase, it will be making a call to the `shares`, `responses` or `justifications` state variable for all participants.


------

We could do this in more gas efficient ways by not having storage variables at all and either using logs or parsing raw tx data, but I'd rather avoid it for the sake of time and simplicity.