### PR TITLE
feat(solidity): add whitelist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,19 @@
 version: 2
 
 jobs:
+  contracts:
+    docker:
+      - image: circleci/node:latest
+    steps:
+      - checkout
+      - run:
+          name: Test Contracts
+          command: |
+              cd solidity
+              yarn
+              yarn build
+              yarn test
+
   build:
     docker:
       - image: circleci/rust:latest
@@ -92,6 +105,7 @@ workflows:
   version: 2
   build_and_test:
     jobs:
+      - contracts
       - build
       - test
       - wasm

--- a/solidity/buidler.config.ts
+++ b/solidity/buidler.config.ts
@@ -1,22 +1,9 @@
 import { usePlugin } from "@nomiclabs/buidler/config";
 
-// use env vars from .env file
-import { config } from "dotenv"
-config({ path: ".env" })
-
 usePlugin("@nomiclabs/buidler-waffle");
-
-const URL = process.env.ENDPOINT || "";
-const PRIVATE_KEY = process.env.PRIVATE_KEY || "";
 
 export default {
     defaultNetwork: "buidlerevm",
-    networks: {
-        mainnet: {
-            url: URL,
-            accounts: [PRIVATE_KEY],
-        },
-    },
     solc: {
         version: "0.6.6",
         optimizer: {

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -4,7 +4,6 @@
   "description": "Contract acting as a broadcast layer for a JF-DKG",
   "scripts": {
     "build": "npx buidler compile",
-    "lint": "prettier --write **/*.sol",
     "test": "npx buidler test",
     "deploy": "npx buidler run --network mainnet scripts/deploy.ts"
   },

--- a/solidity/test/dkg.spec.ts
+++ b/solidity/test/dkg.spec.ts
@@ -32,40 +32,78 @@ describe('DKG', () => {
 
     beforeEach(async () => {
         dkg = await deployContract(deployer, DKG, [THRESHOLD, PHASE_DURATION]);
+        await dkg.whitelist(participants[0].address)
+        await dkg.whitelist(participants[1].address)
+    })
+
+    describe('Whitelist', async () => {
+        it('only owner can whitelist', async () => {
+            // non-owner user tries to whitelist a sybil copy of them
+            dkg = dkg.connect(participants[0]);
+            await expect(dkg.whitelist(participants[2].address)).revertedWith("only owner may whitelist users")
+        })
+
+        it('owner cannot whitelist twice', async () => {
+            await expect(dkg.whitelist(participants[0].address)).revertedWith("user is already whitelisted")
+        })
+
+        it('cannot whitelist once started', async () => {
+            await dkg.start()
+            await expect(dkg.whitelist(participants[2].address)).revertedWith("DKG has already started")
+        });
     })
 
     describe('Registration', async () => {
         it('participants can register', async () => {
+            dkg = dkg.connect(participants[0]);
             await dkg.register(data)
+        })
+
+        it('participants cannot register if not whitelisted', async () => {
+            dkg = dkg.connect(participants[2]);
+            await expect(dkg.register(data)).revertedWith("user is not whitelisted or has already registered")
         })
 
         it('participants cannot register twice', async () => {
+            dkg = dkg.connect(participants[0]);
             await dkg.register(data)
-            await expect(dkg.register(data)).revertedWith("user is already registered")
+            await expect(dkg.register(data)).revertedWith("user is not whitelisted or has already registered")
+
+            // user cannot try to inflate the registrations array with 0-length registrations
+            await expect(dkg.register("0x")).revertedWith("user is not whitelisted or has already registered")
         })
 
         it('cannot register once started', async () => {
+            // user is whitelisted but they dont' register in time
+            await dkg.whitelist(participants[2].address)
             await dkg.start()
+
+            dkg = dkg.connect(participants[2]);
             await expect(dkg.register(data)).revertedWith("DKG has already started")
         });
 
         it('only owner can start the DKG', async () => {
-            await expect(dkg.connect(participants[0]).start()).revertedWith("only contract deployer may start the DKG")
+            await expect(dkg.connect(participants[0]).start()).revertedWith("only owner may start the DKG")
         });
 
         it('cannot publish if not registered', async () => {
             expect(dkg.connect(participants[1]).publish(data)).revertedWith("you are not registered!");
         })
+
     })
 
-    it('has gaps', async() => {
+    it('e2e', async() => {
         const pubkey1 = "0x123";
         await dkg.connect(participants[0]).register(pubkey1)
 
         const pubkey2 = "0x456";
         await dkg.connect(participants[1]).register(pubkey2)
 
+        expect(await dkg.inPhase()).to.equal(0);
+
         await dkg.start()
+
+        expect(await dkg.inPhase()).to.equal(1);
 
         // only the second participant publishes their shares
         const my_shares = "0x123456";
@@ -76,6 +114,7 @@ describe('DKG', () => {
         expect(shares[1]).to.equal(my_shares)
 
         await timeTravel(PHASE_DURATION)
+        expect(await dkg.inPhase()).to.equal(2);
 
         // only the second participant publishes their responses
         const my_responses = "0x234567";
@@ -86,6 +125,7 @@ describe('DKG', () => {
         expect(responses[1]).to.equal(my_responses)
 
         await timeTravel(PHASE_DURATION)
+        expect(await dkg.inPhase()).to.equal(3);
 
         // only the second participant publishes their justifications
         const my_justifications = "0x345678";
@@ -94,6 +134,9 @@ describe('DKG', () => {
         const justifications = await dkg.getJustifications()
         expect(justifications[0]).to.equal("0x")
         expect(justifications[1]).to.equal(my_justifications)
+
+        await timeTravel(PHASE_DURATION)
+        await expect(dkg.inPhase()).revertedWith("VM Exception while processing transaction: revert DKG Ended")
     })
 
     describe('Shares', async () => {
@@ -184,7 +227,8 @@ describe('DKG', () => {
         expect(await dkg.inPhase()).to.equal(0);
         await dkg.start()
         expect(await dkg.inPhase()).to.equal(1);
-        await timeTravel(PHASE_DURATION + 1)
+        // we need to mine 1 extra block here for the phase to change
+        await timeTravel(PHASE_DURATION+ 1)
         expect(await dkg.inPhase()).to.equal(2);
         await timeTravel(PHASE_DURATION + 1)
         expect(await dkg.inPhase()).to.equal(3);


### PR DESCRIPTION
- adds a whitelist which allows the user to specify which accounts may register for the DKG:
  - only owner can call the `whitelist` function
  - a user cannot be whitelisted twice
  - a user can only call `register` if they've been whitelisted before
  - `whitelist` cannot be called after `start` has been called 
- uses an enum for disallowing users from registering twice (instead of allowing them to register multiple times and potentially inflate the registrations array by submitting empty pubkeys)
- adds tests for the new functionalities
- Driveby change: Removes deployment params from `buidler.config`