### PR TITLE
Resharing e2e test

### DIFF
--- a/crates/dkg-core/src/node.rs
+++ b/crates/dkg-core/src/node.rs
@@ -221,6 +221,10 @@ mod tests {
         // 4-of-6 to 3-of-4 (3 leave, 1 joins)
         dkg_resharing_e2e_curve::<bls12_377::G1Curve, G1Scheme<BLS12_377>>(true, 3, 1, 3, 4, 6)
             .await;
+
+        // 4-of-6 to 3-of-4 (2 leave, no-one joins, goes to phase 3)
+        dkg_resharing_e2e_curve::<bls12_377::G1Curve, G1Scheme<BLS12_377>>(false, 2, 0, 3, 4, 6)
+            .await;
     }
 
     #[tokio::test]
@@ -238,7 +242,12 @@ mod tests {
 
     #[tokio::test]
     async fn dkg_resharing_e2e_all_leave_downsize() {
+        // 4-of-6 -> 3-of-4
         dkg_resharing_e2e_curve::<bls12_377::G1Curve, G1Scheme<BLS12_377>>(true, 6, 4, 3, 4, 6)
+            .await;
+
+        // 7-of-8 -> 3-of-3
+        dkg_resharing_e2e_curve::<bls12_377::G1Curve, G1Scheme<BLS12_377>>(true, 8, 3, 3, 7, 8)
             .await;
     }
 

--- a/crates/dkg-core/src/primitives/common.rs
+++ b/crates/dkg-core/src/primitives/common.rs
@@ -179,14 +179,8 @@ pub fn process_shares_get_all<C: Curve>(
     let mut publics = PublicInfo::<C>::new();
     let valid_shares = bundles
         .iter()
-        // check the ones that are not from us
-        .filter(|b| {
-            if let Some(di) = my_dealer_idx {
-                return b.dealer_idx != di;
-            } else {
-                return true;
-            }
-        })
+        // check the ones that are not from us (do not filter if there was no dealer idx specified)
+        .filter(|b| my_dealer_idx.map(|idx| b.dealer_idx != idx).unwrap_or(true))
         //check the ones with a valid dealer index
         .filter(|b| dealers.contains_index(b.dealer_idx))
         // only consider public polynomial of the right form

--- a/crates/dkg-core/src/primitives/common.rs
+++ b/crates/dkg-core/src/primitives/common.rs
@@ -160,6 +160,7 @@ pub fn compute_bundle_response(
 pub fn process_shares_get_all<C: Curve>(
     dealers: &Group<C>,
     share_holders: &Group<C>,
+    my_dealer_idx: Option<Idx>,
     my_idx: Idx,
     my_private: &C::Scalar,
     bundles: &[BundledShares<C>],
@@ -179,8 +180,14 @@ pub fn process_shares_get_all<C: Curve>(
     let valid_shares = bundles
         .iter()
         // check the ones that are not from us
-        .filter(|b| b.dealer_idx != my_idx)
-        // check the ones with a valid dealer index
+        .filter(|b| {
+            if let Some(di) = my_dealer_idx {
+                return b.dealer_idx != di;
+            } else {
+                return true;
+            }
+        })
+        //check the ones with a valid dealer index
         .filter(|b| dealers.contains_index(b.dealer_idx))
         // only consider public polynomial of the right form
         .filter(|b| b.public.degree() == share_holders.threshold - 1)

--- a/crates/dkg-core/src/primitives/joint_feldman.rs
+++ b/crates/dkg-core/src/primitives/joint_feldman.rs
@@ -157,6 +157,7 @@ impl<C: Curve> Phase1<C> for DKGWaitingShare<C> {
         let (shares, publics, statuses) = process_shares_get_all(
             &self.info.group,
             &self.info.group,
+            Some(my_idx),
             my_idx,
             &self.info.private_key,
             bundles,

--- a/crates/dkg-core/src/primitives/resharing.rs
+++ b/crates/dkg-core/src/primitives/resharing.rs
@@ -200,6 +200,7 @@ impl<C: Curve> Phase1<C> for RDKGWaitingShare<C> {
         let (mut shares, mut publics, mut statuses) = process_shares_get_all(
             &self.info.prev_group,
             &self.info.new_group,
+            self.info.prev_index,
             my_idx,
             &self.info.private_key,
             bundles,

--- a/crates/dkg-core/src/primitives/resharing.rs
+++ b/crates/dkg-core/src/primitives/resharing.rs
@@ -205,6 +205,16 @@ impl<C: Curve> Phase1<C> for RDKGWaitingShare<C> {
             &self.info.private_key,
             bundles,
         )?;
+
+        // set the status to true for any dealer that is also a share holder
+        // we compare the public keys from the previous group to the new group
+        // to know if that is the case
+        for prev in self.info.prev_group.nodes.iter() {
+            if let Some(nidx) = self.info.new_group.index(prev.key()) {
+                statuses.set(prev.id(), nidx, Status::Success);
+            }
+        }
+
         println!(
             "{} - PROCESS SHARES: {:?} -> {:?} - {}",
             self.info.new_index.as_ref().unwrap(),

--- a/crates/dkg-core/src/primitives/status.rs
+++ b/crates/dkg-core/src/primitives/status.rs
@@ -97,24 +97,14 @@ impl fmt::Display for StatusMatrix {
 
 impl StatusMatrix {
     /// Returns a MxN Status Matrix (M = dealers, N = share_holders) where all elements
-    /// are initialized to `default`. The elements on the diagonal (i==j) are by initialized
-    /// to `Success`, since the dealer is assumed to succeed
+    /// are initialized to `default`.
     ///
     /// # Panics
     ///
     /// If `dealers > share_holders`
     pub fn new(dealers: usize, share_holders: usize, default: Status) -> StatusMatrix {
-        debug_assert!(
-            dealers <= share_holders,
-            "dealers cannot be more than share holders"
-        );
-
         let m = (0..dealers)
-            .map(|i| {
-                let mut bs = bitvec![default.to_bool() as u8; share_holders];
-                bs.set(i, Status::Success.to_bool());
-                bs
-            })
+            .map(|_| bitvec![default.to_bool() as u8; share_holders])
             .collect();
 
         Self(m)
@@ -192,18 +182,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn diagonal_success() {
-        let matrix = StatusMatrix::new(10, 10, Status::Complaint);
-        for (i, get_for_dealer) in matrix.into_iter().enumerate() {
-            assert_eq!(get_for_dealer.get(i).unwrap(), &true);
-        }
-    }
-
-    #[test]
     fn set() {
         let mut matrix = StatusMatrix::new(3, 3, Status::Complaint);
-        let status = matrix.get(1, 1);
-        assert_eq!(status, Status::Success);
         matrix.set(1, 1, Status::Complaint);
         let status = matrix.get(1, 1);
         assert_eq!(status, Status::Complaint);
@@ -211,7 +191,8 @@ mod tests {
 
     #[test]
     fn get_for_dealer() {
-        let matrix = StatusMatrix::new(3, 3, Status::Complaint);
+        let mut matrix = StatusMatrix::new(3, 3, Status::Complaint);
+        matrix.set(1, 1, Status::Success);
         let get_for_dealer = matrix.get_for_dealer(1);
         assert_eq!(get_for_dealer, &bitvec![0, 1, 0]);
     }
@@ -243,13 +224,7 @@ mod tests {
         let s = matrix.to_string();
         assert_eq!(
             s,
-            "-> dealer 0: [100]\n-> dealer 1: [010]\n-> dealer 2: [001]\n"
+            "-> dealer 0: [000]\n-> dealer 1: [000]\n-> dealer 2: [000]\n"
         );
-    }
-
-    #[test]
-    #[should_panic(expected = "dealers cannot be more than share holders")]
-    fn dealers_more_than_shareholders_panics() {
-        StatusMatrix::new(6, 5, Status::Complaint);
     }
 }


### PR DESCRIPTION
Cherrypicks @nikkolasg patch which fixes the dealer indexes getting out of alignment during re-sharing. Adds an E2E test which verifies that the fix is correct, and also ensures that the DKG can terminate in 2 rounds if the participants who are being removed from the group still decide to participate.