### PR TITLE
Resharing CLI

### DIFF
--- a/crates/dkg-cli/README.md
+++ b/crates/dkg-cli/README.md
@@ -61,6 +61,34 @@ Optional arguments:
                            the path where the resulting of the DKG will be stored (stdout if none provided)
 ```
 
+### Resharing
+
+After a DKG deal has been done, you may want to add or remove members from the group.
+This is done via the re-sharing command. If you are a member that has already participated
+in a previous round of the DKG, you must pass the `share` parameter. If you are a new member,
+you should specify the threshold polynomial which was generated in the previous round (you can get
+that from any of the previous members)
+
+
+```
+Usage: dkg-cli reshare [OPTIONS]
+
+Optional arguments:
+  -h, --help
+  -n, --node-url NODE-URL  the celo node's endpoint
+  -p, --private-key PRIVATE-KEY
+                           path to your celo private key (hint: use the `keygen` command to generate a new one if you don't have one)
+  -c, --contract-address CONTRACT-ADDRESS
+                           the DKG resharing contract's address
+  -o, --output-path OUTPUT-PATH
+                           the path where the result of the DKG will be stored (stdout if none provided)
+  -s, --share SHARE        your BLS share which was produced from the last DKG round (skip this argument if you do not have one)
+  -P, --previous-contract-address PREVIOUS-CONTRACT-ADDRESS
+                           the address of the previous DKG contract (used to fetch the previous group's information)
+  --public-polynomial PUBLIC-POLYNOMIAL
+                           the public polynomial which was produced in the previous DKG
+```
+
 ### Deploying the contract
 
 ```

--- a/crates/dkg-cli/resharing_test.sh
+++ b/crates/dkg-cli/resharing_test.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+NODE_URL="https://alfajores-forno.celo-testnet.org"
+
+# We have 5 pre-funded Celo accounts on Alfajores via the faucet
+# https://celo.org/developers/faucet
+ACC1='{"address":"0xb41998dc0db80898e691127ed06444ae90a0724b","privateKey":"0b9c5fa5b83e7b7625c7fee0f576cd2118786733e13c2a83bfe771d9d4fd0fb3"}'
+ACC2='{"address":"0x48ad174c5b3863d9c129e8e700cd452a14b3c627","privateKey":"334dfa0dc5abeb2288f83374fb7b87c4dcc68ad4f3caffc961685f4011b9cb76"}'
+ACC3='{"address":"0x5b8e00d725225bcd138062b187239893a8e99c27","privateKey":"7e7b2279508e0f7ad3b028773fa53bf11933ed716e6c55b95ef2073afcce4f4c"}'
+ACC4='{"address":"0xc46ba6ba7604cccd16196878d98adbb610d7346a","privateKey":"ef0c8c2e816633fd336defe3f824bec141b2d2d01267d38344d55bb2fce05da6"}'
+ACC5='{"address":"0x111e8d6dffa22859efa38af6b1d7f0fb21840576","privateKey":"c5183dde6c2431505e2a567bb9f69d7aa90e45295be9324abee773f85d6101cf"}'
+
+# Results of a previous DKG round with 4 participants. The re-sharing will convert
+# the previous 3-of-4 deal to a 4-of-5 one.
+OLD_CONTRACT="de8542be84aa7f6c382c1b1bfa93283f24fa7ca6"
+PUBLIC_POLYNOMIAL="0300000000000000dd51cfd48123c2836a0de36270b2f10e55001bad137aee176b689e17d28b91e27af59f989a943afc9bb511bae6391800585688c0a2465af3966de1b8ec451aa0194ab4436692cbbd1e868182faea2eff72cebba992738690e77d24b0ae59dd00a7a745589d68fceadda727613d23ed18b6b5322cf7f6ea0785c139cfba86f06300a5be7def4367376edddb4f82dc7300bb1a97786e84c508c468f1d59aeec2b71a90928feb8c3da40a2301fc8a921c03594d360a4b74e781ca7ac2a36711180178dca759206c79485e2c7b6b5edf279715eea0b71075c9c05aeff23fd67af7611cc577fa2b00a135d576229f13c07101b678cf6ad8e1f82b4520f3167964d9ff69f3dc49adce1837dfb2b84f65cfceb689ffa39c29a1b6aa8b7abac89a0f8f80"
+ACC1_SHARE="00000000a46799e27bb268a79b430977b5de7dd7b8c6b16a33dbc9556c3e1a56e37cb504"
+ACC2_SHARE="01000000527cc20fcbf95caf0aa514d624438fe2f6206f11ad4d753c058cec273572f20d"
+ACC3_SHARE="03000000d14911c90127d94914b34b139655e0ae372dfbc363329aaa92633d8fa0890e10"
+ACC4_SHARE="020000000b1d955ca220ccdedc74d5d4c5703e997578629c5337edc22d2a852935884805"
+
+# This example uses a threshold of 4 with each phase lasting 7 blocks (~45 sec)
+THRESHOLD=4
+PHASE_DURATION=7
+
+private_key() {
+    echo $1 | jq -r '.privateKey'
+}
+
+address() {
+    RES=$(echo $1 | jq -r '.address')
+    echo ${RES#"0x"}
+}
+
+# First we deploy the resharing contract and get its address
+ADDR=$(cargo run --bin dkg-cli deploy \
+    -n $NODE_URL \
+    -p $(private_key $ACC1) \
+    --threshold $THRESHOLD \
+    --phase-duration $PHASE_DURATION)
+# strip the unused info
+ADDR=${ADDR#"Contract deployed at: 0x"}
+
+# The admin allows all addresses (new ones too)
+cargo run --bin dkg-cli -- allow \
+    -n $NODE_URL \
+    -p $(private_key $ACC1) \
+    -c $ADDR \
+    -a $(address $ACC1) \
+    -a $(address $ACC2) \
+    -a $(address $ACC3) \
+    -a $(address $ACC4) \
+    -a $(address $ACC5)
+ 
+# Resharing commands are almost the same as the normal DKG commands, but you also
+# have to provide some additional info from the previous DKG, the contract's address
+# and the public polynomial which was computed
+# - if you were a previous participant you also need to supply your share
+reshare() {
+    yes | cargo run --bin dkg-cli -- reshare \
+        -n $NODE_URL \
+        -p $(private_key $1) \
+        -c $ADDR \
+        -o $3 \
+        --share $2 \
+        --public-polynomial $PUBLIC_POLYNOMIAL \
+        --previous-contract-address $OLD_CONTRACT
+}
+
+new_member() {
+    yes | cargo run --bin dkg-cli -- reshare \
+        -n $NODE_URL \
+        -p $(private_key $1) \
+        -c $ADDR \
+        -o $2 \
+        --public-polynomial $PUBLIC_POLYNOMIAL \
+        --previous-contract-address $OLD_CONTRACT
+}
+
+# Each participant launches the job
+reshare $ACC1 $ACC1_SHARE ./new_acc1_share &
+reshare $ACC2 $ACC2_SHARE ./new_acc2_share &
+reshare $ACC3 $ACC3_SHARE ./new_acc3_share &
+reshare $ACC4 $ACC4_SHARE ./new_acc4_share &
+
+# the 5th participant is new
+new_member $ACC5 ./new_acc5_share &
+  
+# # sleep 10 seconds so that all participants register
+sleep 10
+
+# go!
+cargo run --bin dkg-cli -- start \
+    -n $NODE_URL \
+    -p $(private_key $ACC1) \
+    -c $ADDR

--- a/crates/dkg-cli/src/actions.rs
+++ b/crates/dkg-cli/src/actions.rs
@@ -3,22 +3,26 @@ use crate::{
     opts::*,
 };
 use rand::RngCore;
-use std::{fs::File, io::Write};
+use std::{fs::File, io::Write, sync::Arc};
 
 use dkg_core::{
-    primitives::{joint_feldman::*, *},
+    primitives::{joint_feldman::*, resharing::RDKG, *},
     DKGPhase, Phase2Result,
 };
 
 use anyhow::Result;
 use ethers::prelude::*;
 use rustc_hex::{FromHex, ToHex};
+use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 
-use threshold_bls::poly::Idx;
 use threshold_bls::{group::Curve, sig::Scheme};
+use threshold_bls::{
+    poly::{Idx, PublicPoly},
+    sig::Share,
+};
 
-#[derive(serde::Serialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 struct CeloKeypairJson {
     address: Address,
     #[serde(rename = "privateKey")]
@@ -100,6 +104,49 @@ pub async fn start(opts: StartOpts) -> Result<()> {
     Ok(())
 }
 
+pub async fn reshare<S, C, R>(opts: ReshareConfig, rng: &mut R) -> Result<()>
+where
+    C: Curve,
+    // We need to bind the Curve's Point and Scalars to the Scheme
+    S: Scheme<Public = <C as Curve>::Point, Private = <C as Curve>::Scalar>,
+    R: RngCore,
+{
+    let provider = Provider::<Http>::try_from(opts.node_url.as_str())?;
+    let client = Arc::new(opts.private_key.parse::<Wallet>()?.connect(provider));
+
+    // we need the previous group and public poly for resharing
+    let previous_group = {
+        let previous_dkg = DKGContract::new(opts.previous_contract_address, client.clone());
+        let previous_group = previous_dkg.get_bls_keys().call().await?;
+        pubkeys_to_group::<C>(previous_group)?
+    };
+
+    let public_poly = opts.public_polynomial.from_hex::<Vec<u8>>()?;
+    let public_poly: PublicPoly<C> = bincode::deserialize(&public_poly)?;
+
+    let dkg = DKGContract::new(opts.contract_address, client.clone());
+
+    let (private_key, public_key) = S::keypair(rng);
+
+    register::<S>(&dkg, &public_key).await?;
+    let new_group = get_group::<C>(&dkg).await?;
+
+    let phase0 = if let Some(share) = opts.share {
+        let share = share.from_hex::<Vec<u8>>()?;
+        let share: Share<C::Scalar> = bincode::deserialize(&share)?;
+        let dkg_output = DKGOutput {
+            share,
+            qual: previous_group,
+            public: public_poly,
+        };
+        RDKG::new_from_share(private_key, dkg_output, new_group)
+    } else {
+        RDKG::new_member(private_key, previous_group, public_poly, new_group)
+    }?;
+
+    run_dkg(dkg, phase0, rng, opts.output_path).await
+}
+
 pub async fn run<S, C, R>(opts: DKGConfig, rng: &mut R) -> Result<()>
 where
     C: Curve,
@@ -115,24 +162,46 @@ where
     let (private_key, public_key) = S::keypair(rng);
 
     // 2. Register
+    register::<S>(&dkg, &public_key).await?;
+
+    // Get the group info
+    let group = get_group::<C>(&dkg).await?;
+    let phase0 = DKG::new(private_key, group)?;
+
+    run_dkg(dkg, phase0, rng, opts.output_path).await
+}
+
+async fn register<S: Scheme>(
+    dkg: &DKGContract<Http, Wallet>,
+    public_key: &S::Public,
+) -> Result<()> {
     println!("Registering...");
-    let public_key_serialized = bincode::serialize(&public_key)?;
+    let public_key_serialized = bincode::serialize(public_key)?;
     let pending_tx = dkg.register(public_key_serialized).send().await?;
     let _tx_receipt = dkg.pending_transaction(pending_tx).await?;
 
     // Wait for Phase 1
     wait_for_phase(&dkg, 1).await?;
 
-    // Get the group info
+    Ok(())
+}
+
+async fn get_group<C: Curve>(dkg: &DKGContract<Http, Wallet>) -> Result<Group<C>> {
     let group = dkg.get_bls_keys().call().await?;
     let participants = dkg.get_participants().call().await?;
+    confirm_group(&group, participants)?;
 
+    let group = pubkeys_to_group::<C>(group)?;
+    Ok(group)
+}
+
+fn confirm_group(pubkeys: &(U256, Vec<Vec<u8>>), participants: Vec<Address>) -> Result<()> {
     // print some debug info
     println!(
         "Will run DKG with the group listed below and threshold {}",
-        group.0
+        pubkeys.0
     );
-    for (bls_pubkey, address) in group.1.iter().zip(&participants) {
+    for (bls_pubkey, address) in pubkeys.1.iter().zip(&participants) {
         let key = bls_pubkey.to_hex::<String>();
         println!("{:?} -> {}", address, key)
     }
@@ -146,7 +215,12 @@ where
         return Err(anyhow::anyhow!("User rejected group choice."));
     }
 
-    let nodes = group
+    Ok(())
+}
+
+// Pass the result of `get_bls_keys` to convert the raw data to a group
+fn pubkeys_to_group<C: Curve>(pubkeys: (U256, Vec<Vec<u8>>)) -> Result<Group<C>> {
+    let nodes = pubkeys
         .1
         .into_iter()
         .filter(|pubkey| !pubkey.is_empty()) // skip users that did not register
@@ -157,15 +231,10 @@ where
         })
         .collect::<Result<_>>()?;
 
-    let group = Group {
-        threshold: group.0.as_u64() as usize,
+    Ok(Group {
+        threshold: pubkeys.0.as_u64() as usize,
         nodes,
-    };
-
-    // Instantiate the DKG with the group info
-    let phase0 = DKG::new(private_key, group)?;
-
-    run_dkg(dkg, phase0, rng, opts.output_path).await
+    })
 }
 
 // Shared helper for running the DKG in both normal and re-sharing mode

--- a/crates/dkg-cli/src/main.rs
+++ b/crates/dkg-cli/src/main.rs
@@ -23,6 +23,7 @@ async fn main() -> anyhow::Result<()> {
         Command::Start(opts) => start(opts).await?,
         Command::Deploy(opts) => deploy(opts).await?,
         Command::Allow(opts) => allow(opts).await?,
+        Command::Reshare(opts) => reshare::<Scheme, Curve, _>(opts, rng).await?,
     };
 
     Ok(())

--- a/crates/dkg-cli/src/opts.rs
+++ b/crates/dkg-cli/src/opts.rs
@@ -18,6 +18,9 @@ pub enum Command {
     #[options(help = "runs the DKG and produces your share")]
     Run(DKGConfig),
 
+    #[options(help = "runs the DKG and produces your share")]
+    Reshare(ReshareConfig),
+
     #[options(help = "deploy the DKG smart contract")]
     Deploy(DeployOpts),
 
@@ -52,9 +55,43 @@ pub struct DKGConfig {
     pub contract_address: Address,
 
     #[options(
-        help = "the path where the resulting of the DKG will be stored (stdout if none provided)"
+        help = "the path where the result of the DKG will be stored (stdout if none provided)"
     )]
     pub output_path: Option<String>,
+}
+
+#[derive(Debug, Options, Clone)]
+pub struct ReshareConfig {
+    help: bool,
+
+    #[options(help = "the celo node's endpoint")]
+    pub node_url: String,
+
+    #[options(
+        help = "path to your celo private key (hint: use the `keygen` command to generate a new one if you don't have one)"
+    )]
+    pub private_key: String,
+
+    #[options(help = "the DKG resharing contract's address")]
+    pub contract_address: Address,
+
+    #[options(
+        help = "the path where the result of the DKG will be stored (stdout if none provided)"
+    )]
+    pub output_path: Option<String>,
+
+    #[options(
+        help = "your BLS share which was produced from the last DKG round (skip this argument if you do not have one)"
+    )]
+    pub share: Option<String>,
+
+    #[options(
+        help = "the address of the previous DKG contract (used to fetch the previous group's information)"
+    )]
+    pub previous_contract_address: Address,
+
+    #[options(help = "the public polynomial which was produced in the previous DKG")]
+    pub public_polynomial: String,
 }
 
 #[derive(Debug, Options, Clone)]


### PR DESCRIPTION
Exposes the re-sharing functionality via CLI. A new bash script is added to illustrate this procedure end to end.