### PR TITLE
Fix threshold-bls-ffi create build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,7 +348,7 @@ dependencies = [
  "lru",
  "once_cell",
  "rand",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "thiserror",
 ]
 
@@ -587,7 +587,7 @@ dependencies = [
  "bincode",
  "bitvec",
  "rand",
- "rand_core 0.6.3",
+ "rand_core",
  "serde",
  "static_assertions",
  "thiserror",
@@ -899,7 +899,7 @@ dependencies = [
  "num-traits",
  "quick-error 2.0.1",
  "rand",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -940,18 +940,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.3",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -961,14 +951,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.3",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 
 [[package]]
 name = "rand_core"
@@ -985,7 +969,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core 0.6.3",
+ "rand_core",
 ]
 
 [[package]]
@@ -1256,7 +1240,7 @@ dependencies = [
  "hkdf",
  "proptest",
  "rand",
- "rand_core 0.6.3",
+ "rand_core",
  "serde",
  "sha2",
  "static_assertions",
@@ -1270,8 +1254,8 @@ dependencies = [
  "bincode",
  "bls-crypto",
  "cfg-if 0.1.10",
- "rand_chacha 0.2.2",
- "rand_core 0.6.3",
+ "rand_chacha",
+ "rand_core",
  "serde",
  "threshold-bls",
  "wasm-bindgen",

--- a/crates/threshold-bls-ffi/Cargo.toml
+++ b/crates/threshold-bls-ffi/Cargo.toml
@@ -13,7 +13,7 @@ threshold-bls = { path = "../threshold-bls", default-features = false }
 bls-crypto = { git = "https://github.com/celo-org/bls-crypto" }
 
 rand_core = { version = "0.6.3", default-features = false }
-rand_chacha = { version = "0.2.2", default-features = false }
+rand_chacha = { version = "0.3.1", default-features = false }
 
 wasm-bindgen = { version = "0.2.60", optional = true }
 bincode = { version = "1.2.1", default-features = false }

--- a/crates/threshold-bls-ffi/src/ffi.rs
+++ b/crates/threshold-bls-ffi/src/ffi.rs
@@ -581,7 +581,8 @@ pub unsafe extern "C" fn destroy_sig(signature: *mut Signature) {
 ///
 /// The seed MUST be at least 32 bytes long
 #[no_mangle]
-pub unsafe extern "C" fn threshold_keygen(n: usize, t: usize, seed: &[u8], keys: *mut *mut Keys) {
+pub unsafe extern "C" fn threshold_keygen(n: usize, t: usize, seed: *const Buffer, keys: *mut *mut Keys) {
+    let seed = <&[u8]>::from(unsafe { &*seed });
     let mut rng = get_rng(seed);
     let private = Poly::<PrivateKey>::new_from(t - 1, &mut rng);
     let shares = (0..n)
@@ -749,7 +750,7 @@ mod tests {
 
         let (n, t) = (5, 3);
         let mut keys = MaybeUninit::<*mut Keys>::uninit();
-        unsafe { threshold_keygen(n, t, &seed[..], keys.as_mut_ptr()) };
+        unsafe { threshold_keygen(n, t, &Buffer::from(&seed[..]), keys.as_mut_ptr()) };
         let keys = unsafe { &*keys.assume_init() };
 
         let (message_to_sign, blinding_factor) = if should_blind {

--- a/crates/threshold-bls-ffi/src/lib.rs
+++ b/crates/threshold-bls-ffi/src/lib.rs
@@ -1,5 +1,5 @@
 // add this so that we can be more explicit about unsafe calls inside unsafe functions
-/*#![allow(unused_unsafe)]
+#![allow(unused_unsafe)]
 
 extern crate cfg_if;
 
@@ -14,7 +14,7 @@ cfg_if::cfg_if! {
     }
 }
 
-//use threshold_bls::{poly::Idx, schemes::bls12_377::G2Scheme as SigScheme, sig::Scheme};
+use threshold_bls::{poly::Idx, schemes::bls12_377::G2Scheme as SigScheme, sig::Scheme};
 
 pub(crate) type PublicKey = <SigScheme as Scheme>::Public;
 pub(crate) type PrivateKey = <SigScheme as Scheme>::Private;
@@ -22,4 +22,4 @@ pub(crate) type PrivateKey = <SigScheme as Scheme>::Private;
 pub(crate) const VEC_LENGTH: usize = 8;
 pub(crate) const SIGNATURE_LEN: usize = 48;
 pub(crate) const PARTIAL_SIG_LENGTH: usize =
-    VEC_LENGTH + SIGNATURE_LEN + std::mem::size_of::<Idx>();*/
+    VEC_LENGTH + SIGNATURE_LEN + std::mem::size_of::<Idx>();


### PR DESCRIPTION
Uncomments the lib.rs file in threshold-bls-ffi and fixes the build issues that ensue.
* Use the re-added FFI types in the bls-crypto crate
* Fix a version mismatch between `rand_core` and `rand_chacha` that was causing trait implementation issues
* Fix a warning that the threshold_keygen funciton was not FFI safe

Depends on https://github.com/celo-org/bls-crypto/pull/1
