### PR TITLE
Add missing dependecy for WASM build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -661,8 +661,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -729,6 +731,15 @@ name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "js-sys"
+version = "0.3.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -1254,6 +1265,7 @@ dependencies = [
  "bincode",
  "bls-crypto",
  "cfg-if 0.1.10",
+ "getrandom",
  "rand_chacha",
  "rand_core",
  "serde",

--- a/crates/threshold-bls-ffi/Cargo.toml
+++ b/crates/threshold-bls-ffi/Cargo.toml
@@ -12,6 +12,7 @@ name = "blind_threshold_bls"
 threshold-bls = { path = "../threshold-bls", default-features = false }
 bls-crypto = { git = "https://github.com/celo-org/bls-crypto" }
 
+getrandom = { version = "0.2", default-features = false, optional = true }
 rand_core = { version = "0.6.3", default-features = false }
 rand_chacha = { version = "0.3.1", default-features = false }
 
@@ -22,4 +23,4 @@ serde = { version = "1.0.106", default-features =  false }
 cfg-if = "0.1"
 
 [features]
-wasm = ["wasm-bindgen"]
+wasm = ["wasm-bindgen", "getrandom/js"]


### PR DESCRIPTION
Using `wasm-pack` to build this library for JS environments currently fails because there is a
missing feature dependency `getrandom/js`.

This PR adds `getrandom` as an optional dependency and `getrandom/js` as a feature dependency of
`wasm`. `getrandom` is an indirect dependency of this library and this ensures that the WASM build
includes the features it needs to get randomness from the JS system.
