### PR TITLE
Make parallel an optional feature to support WASM environments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -661,8 +661,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -729,6 +731,15 @@ name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "js-sys"
+version = "0.3.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -1254,6 +1265,7 @@ dependencies = [
  "bincode",
  "bls-crypto",
  "cfg-if 0.1.10",
+ "getrandom",
  "rand_chacha",
  "rand_core",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ dependencies = [
  "ark-serialize",
  "ark-snark",
  "ark-std",
- "blake2",
+ "blake2 0.9.2",
  "derivative",
  "digest 0.9.0",
  "rayon",
@@ -295,6 +295,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cf849ee05b2ee5fba5e36f97ff8ec2533916700fc0758d40d92136a42f3388"
+dependencies = [
+ "digest 0.10.3",
+]
+
+[[package]]
 name = "blake2s_simd"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,6 +327,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+dependencies = [
+ "generic-array 0.14.5",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,7 +347,7 @@ dependencies = [
 [[package]]
 name = "bls-crypto"
 version = "0.3.0"
-source = "git+https://github.com/celo-org/bls-crypto#33c7fc698a7012748816b204891214b18194c09f"
+source = "git+https://github.com/nategraf/bls-crypto?branch=victor/disable-parallel#4a69b5df5897987b8a145fa89d5b6028413a6e67"
 dependencies = [
  "ark-bls12-377",
  "ark-crypto-primitives",
@@ -450,6 +468,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,6 +534,16 @@ checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+dependencies = [
+ "generic-array 0.14.5",
+ "typenum",
 ]
 
 [[package]]
@@ -577,6 +615,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array 0.14.5",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+dependencies = [
+ "block-buffer 0.10.2",
+ "crypto-common",
+ "subtle 2.4.1",
 ]
 
 [[package]]
@@ -1126,7 +1175,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.7.3",
  "digest 0.8.1",
  "fake-simd",
  "opaque-debug 0.2.3",
@@ -1263,8 +1312,10 @@ name = "threshold-bls-ffi"
 version = "0.2.0"
 dependencies = [
  "bincode",
+ "blake2 0.10.4",
  "bls-crypto",
  "cfg-if 0.1.10",
+ "console_error_panic_hook",
  "getrandom",
  "rand_chacha",
  "rand_core",

--- a/crates/threshold-bls-ffi/Cargo.toml
+++ b/crates/threshold-bls-ffi/Cargo.toml
@@ -10,8 +10,7 @@ name = "blind_threshold_bls"
 
 [dependencies]
 threshold-bls = { path = "../threshold-bls", default-features = false }
-# DO NOT MERGE
-bls-crypto = { git = "https://github.com/nategraf/bls-crypto", branch = "victor/disable-parallel" }
+bls-crypto = { git = "https://github.com/celo-org/bls-crypto" }
 
 rand_core = { version = "0.6.3", default-features = false }
 rand_chacha = { version = "0.3.1", default-features = false }

--- a/crates/threshold-bls-ffi/Cargo.toml
+++ b/crates/threshold-bls-ffi/Cargo.toml
@@ -10,17 +10,34 @@ name = "blind_threshold_bls"
 
 [dependencies]
 threshold-bls = { path = "../threshold-bls", default-features = false }
-bls-crypto = { git = "https://github.com/celo-org/bls-crypto" }
+# DO NOT MERGE
+bls-crypto = { git = "https://github.com/nategraf/bls-crypto", branch = "victor/disable-parallel" }
 
-getrandom = { version = "0.2", default-features = false, optional = true }
 rand_core = { version = "0.6.3", default-features = false }
 rand_chacha = { version = "0.3.1", default-features = false }
 
-wasm-bindgen = { version = "0.2.60", optional = true }
 bincode = { version = "1.2.1", default-features = false }
 serde = { version = "1.0.106", default-features =  false }
+
+# Required for WASM interface
+blake2 = { version = "0.10", default-features = false, optional = true }
+getrandom = { version = "0.2", default-features = false, optional = true }
+wasm-bindgen = { version = "0.2.60", optional = true }
+
+# The `console_error_panic_hook` crate provides better debugging of panics by
+# logging them with `console.error`. This is great for development, but requires
+# all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
+# code size when deploying.
+console_error_panic_hook = { version = "0.1.7", optional = true }
 
 cfg-if = "0.1"
 
 [features]
-wasm = ["wasm-bindgen", "getrandom/js"]
+# Build WASM bindings for use in JS environments
+wasm = ["wasm-bindgen", "getrandom/js", "blake2"]
+
+# Include a panic hook for printing panic messages to the JS console.
+wasm-debug = ["wasm", "console_error_panic_hook"]
+
+# Enable parallel computation in arkworks code. Cannot be used with WASM.
+parallel = ["bls-crypto/parallel", "threshold-bls/parallel"]

--- a/crates/threshold-bls-ffi/Cargo.toml
+++ b/crates/threshold-bls-ffi/Cargo.toml
@@ -12,6 +12,7 @@ name = "blind_threshold_bls"
 threshold-bls = { path = "../threshold-bls", default-features = false }
 bls-crypto = { git = "https://github.com/celo-org/bls-crypto" }
 
+getrandom = { version = "0.2", default-features = false, optional = true }
 rand_core = { version = "0.6.3", default-features = false }
 rand_chacha = { version = "0.3.1", default-features = false }
 
@@ -22,4 +23,4 @@ serde = { version = "1.0.106", default-features =  false }
 cfg-if = "0.1"
 
 [features]
-wasm = ["wasm-bindgen"]
+wasm = ["wasm-bindgen", "getrandom/js"]

--- a/crates/threshold-bls-ffi/src/wasm.rs
+++ b/crates/threshold-bls-ffi/src/wasm.rs
@@ -32,7 +32,7 @@ type Result<T> = std::result::Result<T, JsValue>;
 /// - If the same seed is used twice, the blinded result WILL be the same
 pub fn blind(message: Vec<u8>, seed: &[u8]) -> BlindedMessage {
     // convert the seed to randomness
-    let mut rng = get_rng(&seed);
+    let mut rng = get_rng(&[&message, seed]);
 
     // blind the message with this randomness
     let (blinding_factor, blinded_message) = SigScheme::blind_msg(&message, &mut rng);
@@ -265,7 +265,7 @@ pub fn combine(threshold: usize, signatures: Vec<u8>) -> Result<Vec<u8>> {
 ///
 /// The seed MUST be at least 32 bytes long
 pub fn threshold_keygen(n: usize, t: usize, seed: &[u8]) -> Keys {
-    let mut rng = get_rng(seed);
+    let mut rng = get_rng(&[seed]);
     let private = Poly::<PrivateKey>::new_from(t - 1, &mut rng);
     let shares = (0..n)
         .map(|i| private.eval(i as Index))
@@ -339,7 +339,7 @@ impl Keypair {
 /// The seed MUST be at least 32 bytes long
 #[wasm_bindgen]
 pub fn keygen(seed: Vec<u8>) -> Keypair {
-    let mut rng = get_rng(&seed);
+    let mut rng = get_rng(&[&seed]);
     let (private, public) = SigScheme::keypair(&mut rng);
     Keypair { private, public }
 }
@@ -376,16 +376,16 @@ impl Keys {
     }
 }
 
-fn get_rng(digest: &[u8]) -> impl RngCore {
-    let seed = from_slice(digest);
-    ChaChaRng::from_seed(seed)
-}
-
-fn from_slice(bytes: &[u8]) -> [u8; 32] {
-    let mut array = [0; 32];
-    let bytes = &bytes[..array.len()]; // panics if not enough data
-    array.copy_from_slice(bytes);
-    array
+// Creates a PRNG for use in deterministic blinding of messages or in key generation from the array
+// of seeds provided as input.
+fn get_rng(seeds: &[&[u8]]) -> impl RngCore {
+    let mut outer = Blake2s256::new();
+    outer.update("Celo POPRF WASM RNG Seed");
+    for seed in seeds.iter() {
+        outer.update(Blake2s256::digest(seed));
+    }
+    let seed = outer.finalize();
+    ChaChaRng::from_seed(seed.into())
 }
 
 #[cfg(test)]

--- a/crates/threshold-bls/Cargo.toml
+++ b/crates/threshold-bls/Cargo.toml
@@ -20,12 +20,17 @@ sha2 = "0.8"
 # bls12_377
 ark-bls12-377 = { version = "0.3.0" }
 ark-serialize = { version = "0.3.0", features = [ "derive" ] }
-ark-ff = { version = "0.3.0", features = [ "std", "parallel"] }
-ark-ec = { version = "0.3.0", features = [ "std", "parallel"] }
-bls-crypto = { git = "https://github.com/celo-org/bls-crypto" }
+ark-ff = { version = "0.3.0", features = [ "std" ] }
+ark-ec = { version = "0.3.0", features = [ "std" ] }
+# DO NOT MERGE
+bls-crypto = { git = "https://github.com/nategraf/bls-crypto", branch = "victor/disable-parallel" }
 thiserror = "1.0.15"
 bincode = "1.2.1"
 
 [dev-dependencies]
 static_assertions = "1.1.0"
 proptest = "1.0.0"
+
+[features]
+# Enable parallel computation. Cannot be used with WASM.
+parallel = ["ark-ec/parallel", "ark-ff/parallel", "bls-crypto/parallel"]

--- a/crates/threshold-bls/Cargo.toml
+++ b/crates/threshold-bls/Cargo.toml
@@ -22,8 +22,7 @@ ark-bls12-377 = { version = "0.3.0" }
 ark-serialize = { version = "0.3.0", features = [ "derive" ] }
 ark-ff = { version = "0.3.0", features = [ "std" ] }
 ark-ec = { version = "0.3.0", features = [ "std" ] }
-# DO NOT MERGE
-bls-crypto = { git = "https://github.com/nategraf/bls-crypto", branch = "victor/disable-parallel" }
+bls-crypto = { git = "https://github.com/celo-org/bls-crypto" }
 thiserror = "1.0.15"
 bincode = "1.2.1"
 


### PR DESCRIPTION
### Description

Currently, parallel is included as a required feature on arkworks dependencies. Threading is not
supported in WASM environments, so this results in a panic if any code path is encountered that
utilizes multithreading.

This PR puts those features behind a parallel flag on this library.

### Additional changes

Add improved method for CPRNG seed generation, matching what we did in the POPRF code, to allow for
inclusion of the message in the seed after we determine whether it is a backwards compatibility
concern.
