### PR TITLE
[dkg-core] add private key validation

### DIFF
--- a/crates/dkg-core/src/primitives/errors.rs
+++ b/crates/dkg-core/src/primitives/errors.rs
@@ -7,6 +7,11 @@ pub type DKGResult<A> = Result<A, DKGError>;
 #[derive(Debug, Error)]
 /// Errors which may occur during the DKG
 pub enum DKGError {
+    /// PrivateKeyInvalid is raised when the private key is either identity
+    /// element or neutral element in the  finite field.
+    #[error("private key cannot be identity element or neutral element")]
+    PrivateKeyInvalid,
+
     /// PublicKeyNotFound is raised when the private key given to the DKG init
     /// function does not yield a public key that is included in the group.
     #[error("public key not found in list of participants")]

--- a/crates/dkg-core/src/primitives/joint_feldman.rs
+++ b/crates/dkg-core/src/primitives/joint_feldman.rs
@@ -79,6 +79,11 @@ impl<C: Curve> DKG<C> {
         let mut public_key = C::Point::one();
         public_key.mul(&private_key);
 
+        // make sure the private key is not identity element nor neutral element
+        if private_key == C::Scalar::zero() || private_key == C::Scalar::one() {
+            return Err(DKGError::PrivateKeyInvalid);
+        }
+
         // check if the public key is part of the group
         let index = group
             .index(&public_key)


### PR DESCRIPTION
Private key should not be a degenerate value, like zero or one. If so, an error will be returned.