### PR TITLE
Fix Typos in Documentation and Code Comments

### DIFF
--- a/crates/threshold-bls-ffi/README.md
+++ b/crates/threshold-bls-ffi/README.md
@@ -12,7 +12,7 @@ You can generate headerfiles via [`bindgen`]()
 
 This library provides wasm bindings for signing under the `sig/wasm.rs` module. These can be built
 via the [`wasm-pack`](https://github.com/rustwasm/wasm-pack) tool. Depending on the platform you are 
-targetting, you'll need to use a different build flag.
+targeting, you'll need to use a different build flag.
 
 ```
 $ wasm-pack build --target nodejs -- --features=wasm

--- a/crates/threshold-bls/src/sig/sig.rs
+++ b/crates/threshold-bls/src/sig/sig.rs
@@ -33,7 +33,7 @@ pub trait Scheme: Debug {
     }
 }
 
-/// SignatureScheme is the trait that defines the operations of a sinature
+/// SignatureScheme is the trait that defines the operations of a signature
 /// scheme, namely `sign` and `verify`. Below is an example of using the
 /// signature scheme based on BLS, using the BLS12-381 curves.
 ///


### PR DESCRIPTION


Description:  
This pull request corrects minor typographical errors in the documentation and code comments:
- Fixes the spelling of "targetting" to "targeting" in the `crates/threshold-bls-ffi/README.md`.
- Fixes the spelling of "sinature" to "signature" in the `crates/threshold-bls/src/sig/sig.rs` file.

These changes improve the clarity and professionalism of the documentation and codebase. No functional code changes are included.