### PR TITLE
chore: Update circleci xcode image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
 
   build-ios:
     macos:
-      xcode: 15.1.0
+      xcode: 15.4
     steps:
       - checkout
       - run:


### PR DESCRIPTION
15.1 is going to be deprecated.

See https://circleci.com/changelog/deprecation-of-eol-xcode-versions/