### PR TITLE
ci: Enable Docker layer caching on remote-docker jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,8 @@ jobs:
       - image: cimg/base:stable
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          docker_layer_caching: true
       - run:
           name: Build WASM
           command: make wasm
@@ -18,7 +19,8 @@ jobs:
       - image: cimg/base:stable
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          docker_layer_caching: true
       - run:
           name: Build JVM
           command: make jvm
@@ -30,7 +32,8 @@ jobs:
       - image: cimg/base:stable
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          docker_layer_caching: true
       - run:
           name: Build Android
           command: make android


### PR DESCRIPTION
## Summary

Turn on `docker_layer_caching: true` for the three remote-docker jobs (`build-wasm`, `build-jvm`, `build-android`). CircleCI persists the remote Docker host's layer cache between runs, so after the first build every `docker build` reuses unchanged layers (toolchain, wasm-pack, NDK, etc.) instead of rebuilding from scratch.

Requires the CircleCI Performance plan and adds a per-job credit premium for the cache volume, but skips the `build-image` / `save_cache` / `attach_workspace` plumbing a manual-cache approach would otherwise need.

## Test plan

- [ ] First run after merge primes the DLC cache (expect full image build)
- [ ] Subsequent run on an unchanged Dockerfile: `docker build` should be near-instant in all three jobs
- [ ] Touch the Dockerfile and confirm only layers at/after the edit rebuild