### PR TITLE
ffi: Pin iOS deployment target to 15.2 and document mobile floors

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ make jvm
 
 This builds JVM-compatible libraries and places them in `output/jvm`.
 
+### Minimum mobile OS versions
+
+The mobile builds target:
+
+- **Android**: API level 24 (Android 7.0) — set via `ANDROID_API` in `crates/threshold-bls-ffi/cross/Makefile`
+- **iOS**: 15.2 — set via `IPHONEOS_DEPLOYMENT_TARGET` in the same Makefile
+
 ### iOS Build
 
 ```sh

--- a/crates/threshold-bls-ffi/cross/Makefile
+++ b/crates/threshold-bls-ffi/cross/Makefile
@@ -83,6 +83,7 @@ x86_64-linux-android:
 
 .PHONY: $(ARCHS_IOS)
 $(ARCHS_IOS): %:
+	IPHONEOS_DEPLOYMENT_TARGET=15.2 \
 	cargo build $(CARGO_PARAMS) --target $@ --release --lib
 
 $(LIB): $(ARCHS_IOS)


### PR DESCRIPTION
## Summary

- Pin `IPHONEOS_DEPLOYMENT_TARGET=15.2` on the iOS cargo invocation so the static libs are deterministically compatible with iOS 15.2+ regardless of Rust toolchain changes.
- Document both mobile floors (Android API 24, iOS 15.2) in the README, with pointers to where they're configured.

Context: MiniPay's minimum supported targets are Android SDK 24 / iOS 15.2. Android already honors API 24 via \`ANDROID_API\`; the iOS side was implicit via Rust defaults, which can drift.

## Test plan

- [ ] \`make ios\` on macOS produces \`output/ios/libblind_threshold_bls.a\`
- [ ] \`otool -l output/ios/libblind_threshold_bls.a | grep -A3 LC_VERSION_MIN_IPHONEOS\` (or \`LC_BUILD_VERSION\`) reports 15.2