### PR TITLE
chore: Tighten release profile for smaller binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,8 @@ members = [
 [profile.release]
 opt-level = 3
 lto = "thin"
-incremental = true
+codegen-units = 1
+incremental = false
 
 # build all our deps in release mode 
 [profile.dev.package."*"]


### PR DESCRIPTION
## Summary

- Remove \`incremental = true\` from \`[profile.release]\` — the cache is never reused on clean CI builds, it inhibits LTO's whole-program view, and slightly inflates binary size. Pure win.
- Add \`codegen-units = 1\` — lets the optimizer inline and dead-code-eliminate across the whole crate for smaller binaries, at the cost of slower codegen. For a shipped crypto library consumed on mobile, the size/speed trade favors size.

Further optimizations (\`strip\`, \`lto = \"fat\"\`, \`panic = \"abort\"\`) tracked in #169 for separate benchmarking.

## Test plan

- [ ] CI builds green on all existing jobs (wasm, jvm, android, ios)
- [ ] Compare \`output/android/arm64-v8a/libblind_threshold_bls.so\` size before/after to confirm the expected shrink