### PR TITLE
security: Cap bincode deserialize input at 1 MiB

### DIFF
--- a/crates/threshold-bls-ffi/src/ffi.rs
+++ b/crates/threshold-bls-ffi/src/ffi.rs
@@ -5,6 +5,7 @@ use rand_core::{RngCore, SeedableRng};
 use serde::{de::DeserializeOwned, Serialize};
 use threshold_bls::{
     poly::{Idx as Index, Poly},
+    serialization,
     sig::{
         BlindScheme, BlindThresholdScheme, Scheme, Share, SignatureScheme, ThresholdScheme, Token,
     },
@@ -489,7 +490,7 @@ unsafe fn deserialize<T: DeserializeOwned>(
 ) -> bool {
     let buf = unsafe { std::slice::from_raw_parts(in_buf, len) };
 
-    let obj = if let Ok(res) = bincode::deserialize(&buf) {
+    let obj = if let Ok(res) = serialization::deserialize(&buf) {
         res
     } else {
         return false;
@@ -930,7 +931,7 @@ mod tests {
         let message = unsafe { std::slice::from_raw_parts(privkey_buf, PRIVKEY_LEN) };
         assert_eq!(marshalled, message);
 
-        let unmarshalled: PrivateKey = bincode::deserialize(&message).unwrap();
+        let unmarshalled: PrivateKey = serialization::deserialize(&message).unwrap();
         assert_eq!(&unmarshalled, private_key);
 
         let mut de = MaybeUninit::<*mut PrivateKey>::uninit();
@@ -964,7 +965,7 @@ mod tests {
         let message = unsafe { std::slice::from_raw_parts(pubkey_buf, PUBKEY_LEN) };
         assert_eq!(marshalled, message);
 
-        let unmarshalled: PublicKey = bincode::deserialize(&message).unwrap();
+        let unmarshalled: PublicKey = serialization::deserialize(&message).unwrap();
         assert_eq!(&unmarshalled, public_key);
 
         let mut de = MaybeUninit::<*mut PublicKey>::uninit();

--- a/crates/threshold-bls-ffi/src/jni_bridge.rs
+++ b/crates/threshold-bls-ffi/src/jni_bridge.rs
@@ -2,7 +2,7 @@ use jni::objects::{JByteArray, JClass};
 use jni::sys::jboolean;
 use jni::JNIEnv;
 
-use threshold_bls::sig::SignatureScheme;
+use threshold_bls::{serialization, sig::SignatureScheme};
 
 use crate::*;
 
@@ -17,7 +17,7 @@ pub extern "system" fn Java_org_celo_BlindThresholdBls_verify<'local>(
     signature: JByteArray<'local>,
 ) -> jboolean {
     let pub_key_vec = env.convert_byte_array(&pub_key).unwrap();
-    let pub_key: PublicKey = bincode::deserialize(&pub_key_vec).unwrap();
+    let pub_key: PublicKey = serialization::deserialize(&pub_key_vec).unwrap();
     let message = env.convert_byte_array(&message).unwrap();
     let signature = env.convert_byte_array(&signature).unwrap();
 

--- a/crates/threshold-bls-ffi/src/wasm.rs
+++ b/crates/threshold-bls-ffi/src/wasm.rs
@@ -6,6 +6,7 @@ use rand_core::{RngCore, SeedableRng};
 
 use threshold_bls::{
     poly::{Idx as Index, Poly},
+    serialization,
     sig::{
         BlindScheme, BlindThresholdScheme, Scheme, Share, SignatureScheme, ThresholdScheme, Token,
     },
@@ -55,8 +56,8 @@ pub fn blind(message: Vec<u8>, seed: &[u8]) -> BlindedMessage {
 ///
 /// - If unblinding fails.
 pub fn unblind(blinded_signature: &[u8], blinding_factor_buf: &[u8]) -> Result<Vec<u8>> {
-    let blinding_factor: Token<PrivateKey> =
-        bincode::deserialize(blinding_factor_buf).map_err(|err| {
+    let blinding_factor: Token<PrivateKey> = serialization::deserialize(blinding_factor_buf)
+        .map_err(|err| {
             JsValue::from_str(&format!("could not deserialize blinding factor {}", err))
         })?;
 
@@ -76,7 +77,7 @@ pub fn unblind(blinded_signature: &[u8], blinding_factor_buf: &[u8]) -> Result<V
 ///
 /// - If verification fails
 pub fn verify(public_key_buf: &[u8], message: &[u8], signature: &[u8]) -> Result<()> {
-    let public_key: PublicKey = bincode::deserialize(public_key_buf)
+    let public_key: PublicKey = serialization::deserialize(public_key_buf)
         .map_err(|err| JsValue::from_str(&format!("could not deserialize public key {}", err)))?;
 
     // checks the signature on the message hash
@@ -100,7 +101,7 @@ pub fn verify_blind_signature(
     message: &[u8],
     signature: &[u8],
 ) -> Result<()> {
-    let public_key: PublicKey = bincode::deserialize(public_key_buf)
+    let public_key: PublicKey = serialization::deserialize(public_key_buf)
         .map_err(|err| JsValue::from_str(&format!("could not deserialize public key {}", err)))?;
 
     // checks the signature on the message hash
@@ -119,7 +120,7 @@ pub fn verify_blind_signature(
 ///
 /// - If signing fails
 pub fn sign(private_key_buf: &[u8], message: &[u8]) -> Result<Vec<u8>> {
-    let private_key: PrivateKey = bincode::deserialize(private_key_buf)
+    let private_key: PrivateKey = serialization::deserialize(private_key_buf)
         .map_err(|err| JsValue::from_str(&format!("could not deserialize private key {}", err)))?;
 
     SigScheme::sign(&private_key, message)
@@ -133,7 +134,7 @@ pub fn sign(private_key_buf: &[u8], message: &[u8]) -> Result<Vec<u8>> {
 ///
 /// - If signing fails
 pub fn sign_blinded_message(private_key_buf: &[u8], message: &[u8]) -> Result<Vec<u8>> {
-    let private_key: PrivateKey = bincode::deserialize(private_key_buf)
+    let private_key: PrivateKey = serialization::deserialize(private_key_buf)
         .map_err(|err| JsValue::from_str(&format!("could not deserialize private key {}", err)))?;
 
     SigScheme::blind_sign(&private_key, message)
@@ -151,7 +152,7 @@ pub fn sign_blinded_message(private_key_buf: &[u8], message: &[u8]) -> Result<Ve
 /// NOTE: This method must NOT be called with a PrivateKey which is not generated via a
 /// secret sharing scheme.
 pub fn partial_sign(share_buf: &[u8], message: &[u8]) -> Result<Vec<u8>> {
-    let share: Share<PrivateKey> = bincode::deserialize(share_buf).map_err(|err| {
+    let share: Share<PrivateKey> = serialization::deserialize(share_buf).map_err(|err| {
         JsValue::from_str(&format!("could not deserialize private key share {}", err))
     })?;
 
@@ -170,7 +171,7 @@ pub fn partial_sign(share_buf: &[u8], message: &[u8]) -> Result<Vec<u8>> {
 /// NOTE: This method must NOT be called with a PrivateKey which is not generated via a
 /// secret sharing scheme.
 pub fn partial_sign_blinded_message(share_buf: &[u8], message: &[u8]) -> Result<Vec<u8>> {
-    let share: Share<PrivateKey> = bincode::deserialize(share_buf).map_err(|err| {
+    let share: Share<PrivateKey> = serialization::deserialize(share_buf).map_err(|err| {
         JsValue::from_str(&format!("could not deserialize private key share {}", err))
     })?;
 
@@ -190,7 +191,7 @@ pub fn partial_sign_blinded_message(share_buf: &[u8], message: &[u8]) -> Result<
 ///
 /// - If verification fails
 pub fn partial_verify(polynomial_buf: &[u8], blinded_message: &[u8], sig: &[u8]) -> Result<()> {
-    let polynomial: Poly<PublicKey> = bincode::deserialize(polynomial_buf)
+    let polynomial: Poly<PublicKey> = serialization::deserialize(polynomial_buf)
         .map_err(|err| JsValue::from_str(&format!("could not deserialize polynomial {}", err)))?;
 
     SigScheme::partial_verify(&polynomial, blinded_message, sig)
@@ -209,7 +210,7 @@ pub fn partial_verify_blind_signature(
     blinded_message: &[u8],
     sig: &[u8],
 ) -> Result<()> {
-    let polynomial: Poly<PublicKey> = bincode::deserialize(polynomial_buf)
+    let polynomial: Poly<PublicKey> = serialization::deserialize(polynomial_buf)
         .map_err(|err| JsValue::from_str(&format!("could not deserialize polynomial {}", err)))?;
 
     SigScheme::verify_blind_partial(&polynomial, blinded_message, sig)

--- a/crates/threshold-bls/src/curve/bls12377.rs
+++ b/crates/threshold-bls/src/curve/bls12377.rs
@@ -523,6 +523,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::serialization;
     use serde::{de::DeserializeOwned, Serialize};
     use static_assertions::assert_impl_all;
 
@@ -543,7 +544,7 @@ mod tests {
         let ser = bincode::serialize(&sig).unwrap();
         assert_eq!(ser.len(), size);
 
-        let de: E = bincode::deserialize(&ser).unwrap();
+        let de: E = serialization::deserialize(&ser).unwrap();
         assert_eq!(de, sig);
     }
 
@@ -559,7 +560,7 @@ mod tests {
         let ser = bincode::serialize(&sig).unwrap();
         assert_eq!(ser.len(), size);
 
-        let de: E = bincode::deserialize(&ser).unwrap();
+        let de: E = serialization::deserialize(&ser).unwrap();
         assert_eq!(de, sig);
     }
 

--- a/crates/threshold-bls/src/lib.rs
+++ b/crates/threshold-bls/src/lib.rs
@@ -168,6 +168,10 @@ pub mod group;
 /// polynomial.
 pub mod poly;
 
+/// Bounded bincode (de)serialization helpers that cap input size to prevent
+/// OOM from attacker-crafted length prefixes.
+pub mod serialization;
+
 /// BLS Signature implementations. Supports blind and threshold signatures.
 pub mod sig;
 

--- a/crates/threshold-bls/src/serialization.rs
+++ b/crates/threshold-bls/src/serialization.rs
@@ -1,0 +1,111 @@
+//! Bounded bincode (de)serialization.
+//!
+//! Wraps `bincode::deserialize` / `bincode::deserialize_from` with a fixed input
+//! size limit so an attacker-crafted length prefix on a `Vec` field cannot
+//! trigger an exabyte-scale allocation. Encoding options otherwise match
+//! `bincode::deserialize` exactly (little-endian fixint), preserving wire
+//! compatibility with previously serialized data.
+
+use bincode::Options;
+use serde::{de::DeserializeOwned, Deserialize};
+use std::io::Read;
+
+/// Upper bound (in bytes) on any single deserialize call.
+///
+/// 1 MiB comfortably covers a `Poly<PublicKey>` at threshold on the order of
+/// 10k participants while blocking `u64::MAX`-style length-prefix attacks.
+pub const MAX_DESERIALIZE_BYTES: u64 = 1 << 20;
+
+fn options() -> impl Options {
+    // Match `bincode::deserialize` / `bincode::deserialize_from` exactly:
+    // fixint encoding, little-endian (DefaultOptions), trailing bytes allowed.
+    // Only add the size limit on top, so the helper is a true drop-in.
+    bincode::DefaultOptions::new()
+        .with_fixint_encoding()
+        .allow_trailing_bytes()
+        .with_limit(MAX_DESERIALIZE_BYTES)
+}
+
+/// Drop-in replacement for `bincode::deserialize` that enforces
+/// [`MAX_DESERIALIZE_BYTES`].
+pub fn deserialize<'a, T: Deserialize<'a>>(bytes: &'a [u8]) -> bincode::Result<T> {
+    options().deserialize(bytes)
+}
+
+/// Drop-in replacement for `bincode::deserialize_from` that enforces
+/// [`MAX_DESERIALIZE_BYTES`].
+pub fn deserialize_from<R: Read, T: DeserializeOwned>(reader: R) -> bincode::Result<T> {
+    options().deserialize_from(reader)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_normal_input() {
+        let v: Vec<u8> = vec![1, 2, 3, 4];
+        let bytes = bincode::serialize(&v).unwrap();
+        let round: Vec<u8> = deserialize(&bytes).unwrap();
+        assert_eq!(round, v);
+    }
+
+    #[test]
+    fn rejects_oversized_length_prefix() {
+        // `Vec<u8>` bincode format: u64 little-endian length, then payload.
+        // Claim a 2^63-byte vec in only a few bytes of buffer. Without a limit
+        // bincode attempts to allocate ~8 EiB; the bounded version must reject.
+        let mut evil = (i64::MAX as u64).to_le_bytes().to_vec();
+        evil.extend_from_slice(&[0u8; 8]);
+        let result: Result<Vec<u8>, _> = deserialize(&evil);
+        assert!(result.is_err(), "oversized length prefix must be rejected");
+    }
+
+    #[test]
+    fn rejects_length_just_over_limit() {
+        let claimed = MAX_DESERIALIZE_BYTES + 1;
+        let mut evil = claimed.to_le_bytes().to_vec();
+        evil.extend_from_slice(&[0u8; 8]);
+        let result: Result<Vec<u8>, _> = deserialize(&evil);
+        assert!(
+            result.is_err(),
+            "length over MAX_DESERIALIZE_BYTES must be rejected"
+        );
+    }
+
+    #[test]
+    fn deserialize_from_also_bounded() {
+        let mut evil = (i64::MAX as u64).to_le_bytes().to_vec();
+        evil.extend_from_slice(&[0u8; 8]);
+        let result: Result<Vec<u8>, _> = deserialize_from(&evil[..]);
+        assert!(
+            result.is_err(),
+            "deserialize_from must also enforce the limit"
+        );
+    }
+
+    #[test]
+    fn allows_trailing_bytes_like_bincode_top_level() {
+        // `bincode::deserialize` (the free function) uses `allow_trailing_bytes()`;
+        // the bounded helper must match so it's a true drop-in.
+        let v: Vec<u8> = vec![1, 2, 3];
+        let mut bytes = bincode::serialize(&v).unwrap();
+        bytes.extend_from_slice(&[0xAA, 0xBB, 0xCC]); // trailing garbage
+        let round: Vec<u8> = deserialize(&bytes).unwrap();
+        assert_eq!(round, v);
+    }
+
+    #[test]
+    fn rejects_nested_vec_oversized_inner_length() {
+        // `Eval<Vec<u8>>` is the actual shape passed through `partial_verify` and
+        // `aggregate`. A small outer envelope with a malicious inner `Vec<u8>`
+        // length claiming u64::MAX must be rejected — this is the realistic
+        // attack shape, not just a bare `Vec<u8>`.
+        use crate::poly::Eval;
+        let mut evil: Vec<u8> = Vec::new();
+        evil.extend_from_slice(&u64::MAX.to_le_bytes()); // inner Vec<u8> claimed length
+        evil.extend_from_slice(&0u32.to_le_bytes()); // Idx
+        let result: bincode::Result<Eval<Vec<u8>>> = deserialize(&evil);
+        assert!(result.is_err(), "nested oversized Vec must be rejected");
+    }
+}

--- a/crates/threshold-bls/src/sig/blind.rs
+++ b/crates/threshold-bls/src/sig/blind.rs
@@ -1,4 +1,5 @@
 use crate::group::{Element, Point, Scalar};
+use crate::serialization;
 use crate::sig::bls::{common::BLSScheme, BLSError};
 use crate::sig::{BlindScheme, Scheme};
 use rand::RngCore;
@@ -67,7 +68,7 @@ where
     }
 
     fn unblind_sig(t: &Self::Token, sigbuff: &[u8]) -> Result<Vec<u8>, Self::Error> {
-        let mut sig: I::Signature = bincode::deserialize(sigbuff)?;
+        let mut sig: I::Signature = serialization::deserialize(sigbuff)?;
 
         // r^-1 * ( r * H(m)^x) = H(m)^x
         let ri = t.0.inverse().ok_or(BlindError::InvalidToken)?;
@@ -83,9 +84,9 @@ where
         blinded_sig: &[u8],
     ) -> Result<(), Self::Error> {
         // message point
-        let blinded_msg: I::Signature = bincode::deserialize(blinded_msg)?;
+        let blinded_msg: I::Signature = serialization::deserialize(blinded_msg)?;
         // signature point
-        let blinded_sig: I::Signature = bincode::deserialize(blinded_sig)?;
+        let blinded_sig: I::Signature = serialization::deserialize(blinded_sig)?;
 
         if !I::final_exp(public, &blinded_sig, &blinded_msg) {
             return Err(BlindError::from(BLSError::InvalidSig));
@@ -95,7 +96,7 @@ where
 
     fn blind_sign(private: &I::Private, blinded_msg: &[u8]) -> Result<Vec<u8>, Self::Error> {
         // (r * H(m))^x
-        let mut hm: I::Signature = bincode::deserialize(blinded_msg)?;
+        let mut hm: I::Signature = serialization::deserialize(blinded_msg)?;
         hm.mul(private);
         Ok(bincode::serialize(&hm)?)
     }

--- a/crates/threshold-bls/src/sig/bls.rs
+++ b/crates/threshold-bls/src/sig/bls.rs
@@ -1,4 +1,5 @@
 use crate::group::{Element, PairingCurve, Point};
+use crate::serialization;
 use crate::sig::{Scheme, SignatureScheme};
 use std::{fmt::Debug, marker::PhantomData};
 use thiserror::Error;
@@ -39,7 +40,7 @@ pub mod common {
                 h.map(msg).map_err(|_| BLSError::HashingError)?;
                 h
             } else {
-                bincode::deserialize_from(msg)?
+                serialization::deserialize_from(msg)?
             };
 
             h.mul(private);
@@ -54,14 +55,14 @@ pub mod common {
             sig_bytes: &[u8],
             should_hash: bool,
         ) -> Result<(), BLSError> {
-            let sig: Self::Signature = bincode::deserialize_from(sig_bytes)?;
+            let sig: Self::Signature = serialization::deserialize_from(sig_bytes)?;
 
             let h = if should_hash {
                 let mut h = Self::Signature::new();
                 h.map(msg).map_err(|_| BLSError::HashingError)?;
                 h
             } else {
-                bincode::deserialize_from(msg)?
+                serialization::deserialize_from(msg)?
             };
 
             let success = Self::final_exp(public, &sig, &h);

--- a/crates/threshold-bls/src/sig/tblind.rs
+++ b/crates/threshold-bls/src/sig/tblind.rs
@@ -1,4 +1,5 @@
 use crate::poly::{Eval, Poly};
+use crate::serialization;
 use crate::sig::tbls::Share;
 use crate::sig::{BlindScheme, BlindThresholdScheme, Partial, ThresholdScheme};
 use thiserror::Error;
@@ -40,7 +41,7 @@ where
         partial: &[u8],
     ) -> Result<Partial, <Self as BlindThresholdScheme>::Error> {
         // deserialize the sig
-        let partial: Eval<Vec<u8>> = bincode::deserialize(partial)?;
+        let partial: Eval<Vec<u8>> = serialization::deserialize(partial)?;
 
         let partially_unblinded =
             Self::unblind_sig(t, &partial.value).map_err(BlindThresholdError::BlindError)?;
@@ -56,7 +57,7 @@ where
         blind_msg: &[u8],
         blind_partial: &[u8],
     ) -> Result<(), <Self as BlindThresholdScheme>::Error> {
-        let blinded_partial: Eval<Vec<u8>> = bincode::deserialize(blind_partial)?;
+        let blinded_partial: Eval<Vec<u8>> = serialization::deserialize(blind_partial)?;
         let public_i = public.eval(blinded_partial.index);
         Self::blind_verify(&public_i.value, blind_msg, &blinded_partial.value)
             .map_err(BlindThresholdError::BlindError)

--- a/crates/threshold-bls/src/sig/tbls.rs
+++ b/crates/threshold-bls/src/sig/tbls.rs
@@ -1,6 +1,7 @@
 //! Threshold Signatures implementation for any type which implements
 //! [`SignatureScheme`](../trait.SignatureScheme.html)
 use crate::poly::{Eval, Idx, Poly, PolyError};
+use crate::serialization;
 use crate::sig::{Partial, SignatureScheme, ThresholdScheme};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -56,7 +57,7 @@ impl<I: SignatureScheme> ThresholdScheme for I {
         msg: &[u8],
         partial: &[u8],
     ) -> Result<(), <Self as ThresholdScheme>::Error> {
-        let partial: Eval<Vec<u8>> = bincode::deserialize(partial)?;
+        let partial: Eval<Vec<u8>> = serialization::deserialize(partial)?;
 
         let public_i = public.eval(partial.index);
 
@@ -77,8 +78,8 @@ impl<I: SignatureScheme> ThresholdScheme for I {
         let valid_partials: Vec<Eval<Self::Signature>> = partials
             .iter()
             .map(|partial| {
-                let eval: Eval<Vec<u8>> = bincode::deserialize(partial)?;
-                let sig = bincode::deserialize(&eval.value)?;
+                let eval: Eval<Vec<u8>> = serialization::deserialize(partial)?;
+                let sig = serialization::deserialize(&eval.value)?;
                 Ok(Eval {
                     index: eval.index,
                     value: sig,

--- a/crates/threshold-bls/src/test_vectors.rs
+++ b/crates/threshold-bls/src/test_vectors.rs
@@ -2,8 +2,9 @@
 mod tests {
     #[cfg(test)]
     mod bls12_377_vectors {
-        use crate::poly::{Idx, Poly};
+        use crate::poly::{Eval, Idx, Poly};
         use crate::schemes::bls12_377::G2Scheme;
+        use crate::serialization;
         use crate::sig::{Scheme, Share, SignatureScheme, ThresholdScheme};
         use rand_chacha::rand_core::SeedableRng;
         use rand_chacha::ChaChaRng;
@@ -54,6 +55,31 @@ mod tests {
             "3000000000000000e2dac33c610f0a247a82c98324188070164206c0151be6a98d8666e63a36c3804bfcb682f6764ad2307406292f2d2281",
             "3000000000000000f07921d52176cc4f6528005c19eab9d230900b531780e9ddfd1d13f020cf4b559a96a6909c33bfb16bd0e3ca0cdf5d01",
             "30000000000000007711c1febaa06af30f0c9bb19e942b642d21354c25ad392b1c4c3cf4eb0375809afa05bf7defaa17684202e036cfd480",
+        ];
+
+        // Expected bincode encoding of `Poly<PublicKey>` committed from the
+        // three-coefficient private polynomial whose coefficients are the first
+        // three private keys above. Pins the on-the-wire format for a public
+        // polynomial at threshold=3.
+        const EXPECTED_PUBLIC_POLYNOMIAL: &str = "0300000000000000203e261e640d22e0daed558229493c95fb5016c1c8dc5a22dfedb22f14fcb2958466446beb9c309dffa4b4ba52894000f9cab42d8570af09233b9ba06c0fb1c266a866f0e6384edbf176fcb76619f01da297480be4d7b8551b8fa3b9a08e110082ad47f04edc28f22a3c47e2aaf642912d9b710c57c254ef78081a39f2eaeec97a95873789f15555503a1f885fea0e0190826f11ac8e09339391dcf499347db8cd48ae453b0882ea652177b6f73bb673b1381ed7cd91c8f6a0763f4dc97549011a95b30e8dee662342c87ca88914890fba6b376344fbf8669abb4ce5ea62ac1dbd2935320efe5c6ebe5ceee9534187002ae20deb4445768a023d8d499fb1f49608942e0047ec82993fe6447a2abace036352eb6878fae17d5c0b992c7ba74800";
+
+        // Expected bincode encoding of each `Share<PrivateKey>` produced by
+        // evaluating the same three-coefficient private polynomial at indices
+        // 0, 1, 2. Pins the on-the-wire format for threshold-secret shares.
+        const EXPECTED_SHARES: [&str; 3] = [
+            "00000000e01ffa6ec1d860c67c48e2ae0b93b6d03dd07068ebaadcf597d14a9e5708a604",
+            "0100000011433b674c0e0dfc619a72b107c644acc72dbc188b896d6d89e72c4fd94bdf0a",
+            "0200000065bd443b96124ba3cd16575c5b8763b5ad7ddf48a5710cf20c2aec3627d56303",
+        ];
+
+        // Expected bincode encoding of each partial signature
+        // (output of `partial_sign`) on MESSAGES[0] with the three shares
+        // above. Pins the on-the-wire format for partial signatures (the
+        // `Eval<Vec<u8>>` shape).
+        const EXPECTED_PARTIAL_SIGS_ON_MSG0: [&str; 3] = [
+            "300000000000000005f9fc64775de3052bf866d04e40244f81320dc327e98f7e2fb85f2b7d723f5029d0985a26f6a530d390548f096e1a0100000000",
+            "3000000000000000370ee2fc7404010fb6035e4161d5665aa1a50e1ab8fb1dd9c8cd5016adea63914a2d9dd0425cceeefba02ef0d7dd9f0001000000",
+            "300000000000000019d05eff2062b7266f803c83b84321ad92c34aa794b69c3f31e75e8f3e33c2925929a7f926f32c97a2276c1541735e0102000000",
         ];
 
         // Create a deterministic RNG for reproducible key generation
@@ -107,6 +133,82 @@ mod tests {
                         j
                     );
                 }
+            }
+        }
+
+        /// Builds the fixed-coefficient private polynomial, derives the matching
+        /// shares and public polynomial, and returns everything needed by the
+        /// wire-format tests.
+        fn fixed_threshold_setup() -> (Vec<Share<PrivateKey>>, Poly<PublicKey>) {
+            let n = 3;
+            let private_keys: Vec<PrivateKey> = (0..n)
+                .map(get_keypair)
+                .map(|(priv_key, _)| priv_key)
+                .collect();
+            let private_poly = Poly::<PrivateKey>::from(private_keys);
+            let shares = (0..n)
+                .map(|i| {
+                    let eval = private_poly.eval(i as Idx);
+                    Share {
+                        index: eval.index,
+                        private: eval.value,
+                    }
+                })
+                .collect::<Vec<Share<PrivateKey>>>();
+            let public_poly = private_poly.commit();
+            (shares, public_poly)
+        }
+
+        #[test]
+        fn test_wire_format_public_polynomial() {
+            let (_, public_poly) = fixed_threshold_setup();
+
+            // encode side: the top-level bincode output matches the pinned hex
+            let encoded = hex::encode(bincode::serialize(&public_poly).unwrap());
+            assert_eq!(encoded, EXPECTED_PUBLIC_POLYNOMIAL);
+
+            // decode side: the bounded helper accepts the same bytes and
+            // reconstructs the equivalent value
+            let bytes = hex::decode(EXPECTED_PUBLIC_POLYNOMIAL).unwrap();
+            let decoded: Poly<PublicKey> = serialization::deserialize(&bytes)
+                .expect("bounded deserialize must accept pinned wire data");
+            assert_eq!(decoded, public_poly);
+        }
+
+        #[test]
+        fn test_wire_format_shares() {
+            let (shares, _) = fixed_threshold_setup();
+            for (i, share) in shares.iter().enumerate() {
+                let encoded = hex::encode(bincode::serialize(share).unwrap());
+                assert_eq!(encoded, EXPECTED_SHARES[i], "share {} wire format drift", i);
+
+                let bytes = hex::decode(EXPECTED_SHARES[i]).unwrap();
+                let decoded: Share<PrivateKey> = serialization::deserialize(&bytes)
+                    .expect("bounded deserialize must accept pinned wire data");
+                assert_eq!(&decoded, share);
+            }
+        }
+
+        #[test]
+        fn test_wire_format_partial_signatures() {
+            let (shares, _) = fixed_threshold_setup();
+            let msg = MESSAGES[0];
+            for (i, share) in shares.iter().enumerate() {
+                let partial = G2Scheme::partial_sign(share, msg).unwrap();
+                let encoded = hex::encode(&partial);
+                assert_eq!(
+                    encoded, EXPECTED_PARTIAL_SIGS_ON_MSG0[i],
+                    "partial signature {} wire format drift",
+                    i
+                );
+
+                let bytes = hex::decode(EXPECTED_PARTIAL_SIGS_ON_MSG0[i]).unwrap();
+                let decoded: Eval<Vec<u8>> = serialization::deserialize(&bytes)
+                    .expect("bounded deserialize must accept pinned wire data");
+                assert_eq!(decoded.index, share.index);
+                // Re-serialize the decoded value and confirm the bytes round-trip
+                // back to the pinned hex.
+                assert_eq!(bincode::serialize(&decoded).unwrap(), bytes);
             }
         }
 


### PR DESCRIPTION
bincode 1.x pre-allocates `Vec` based on the attacker-controlled u64 length prefix, so a crafted polynomial or partial signature over WASM/FFI/JNI could trigger an ~18 EiB allocation and OOM the host. Add `threshold_bls::serialization::{deserialize, deserialize_from}` wrapping `bincode::DefaultOptions` with `with_fixint_encoding`, `allow_trailing_bytes`, and a 1 MiB limit so
the helper is a true drop-in but rejects oversized length prefixes. Migrate every `bincode::deserialize(_from)` call site.

Also pin wire format for `Poly<PublicKey>`, `Share<PrivateKey>`, and partial signatures (`Eval<Vec<u8>>`) in `test_vectors.rs`, round- tripping each through the bounded helper to guard against config regressions on future dep bumps.