### PR TITLE
chore: Switch dependency updates from Dependabot to Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "local>celo-org/.github:renovate-config"
+  ]
+}


### PR DESCRIPTION
Matches celo-org convention: extend the org-wide preset at celo-org/.github:renovate-config (config:recommended + 7-day minimumReleaseAge + OSV vulnerability alerts + earlyMondays schedule). Same layout as the sibling repo celo-org/blind-threshold-bls-wasm.

Removes .github/dependabot.yml so we don't run both tools in parallel. config:recommended covers both cargo and github-actions, so this closes the cargo dependency-update gap without regressing github-actions coverage.