### PR TITLE
fix: Default cross builds to the ffi feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
 RUST_VERSION ?= 1.95.0
+# Cargo features for the Android/iOS cross builds. The mobile consumers link
+# against the C ABI (threshold.h), which requires "ffi"; without it the
+# produced libraries export no symbols.
+FEATURES ?= ffi
 IMAGE_NAME = celo-bls-rust-$(subst .,_,$(RUST_VERSION))
 OUTPUT_DIR = $(PWD)/output
 CARGO_CACHE_VOLUME = celo-bls-cargo-cache

--- a/crates/threshold-bls-ffi/cross/Makefile
+++ b/crates/threshold-bls-ffi/cross/Makefile
@@ -10,6 +10,9 @@ NDK_HOST_TAG ?= linux-x86_64
 NDK_BIN = $(NDK_HOME)/toolchains/llvm/prebuilt/$(NDK_HOST_TAG)/bin
 ANDROID_DEST = /output/android
 IOS_DEST = ./target/ios
+# The mobile consumers link against the C ABI (threshold.h), which requires
+# the "ffi" feature; without it the produced libraries export no symbols.
+FEATURES ?= ffi
 CARGO_PARAMS = --no-default-features $(if $(FEATURES),--features $(FEATURES))
 
 TARGET_DIR = ../../../target


### PR DESCRIPTION
## What

`make android` passed an empty `FEATURES` through to `cross/Makefile`, which builds with `--no-default-features` — so no `cfg_select!` branch in `crates/threshold-bls-ffi/src/lib.rs` was compiled in and all four Android `.so` files exported **no symbols**. `make ios` had the same problem via the locally-run cross build, producing an empty `.a`. Any consumer linking the C ABI from `threshold.h` (e.g. the JNA-based React Native bindings) would fail at runtime with `UnsatisfiedLinkError`.

This defaults `FEATURES ?= ffi` in both Makefiles. The root Makefile needs its own default because the `android` target passes `-e FEATURES="$(FEATURES)"` into Docker, and an empty-but-set environment variable would defeat a `?=` default downstream. Overrides via `make android FEATURES=...` still work.

## Verification

- Dry-runs show `--features ffi` reaching cargo on all three paths: the root `android` target, the env-var route Docker uses, and local cross invocation (`make ios`)
- A host build with the exact cargo flags exports all 25 `threshold.h` symbols (`blind`, `combine`, `keygen`, `partial_sign`, …); the featureless build exports zero
- The full Docker+NDK cross-compilation itself is unchanged — only the feature flag reaching it