### PR TITLE
build: Strip symbols from release binaries

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,8 @@
+# On wasm, `-C strip` removes all custom sections, including `target_features`.
+# wasm-opt (run by wasm-pack) reads that section to know which post-MVP
+# features (e.g. bulk memory) the module uses; without it, validation fails.
+# Stripping gains nothing there anyway: wasm-opt already drops debug info and
+# names from the published pkg. This override cancels the release profile's
+# `strip = "symbols"` for wasm only.
+[target.wasm32-unknown-unknown]
+rustflags = ["-C", "strip=none"]

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ pkg/
 #Cargo.lock
 
 NDK
-.cargo
 react-native
 
 solidity/cache

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ opt-level = 3
 lto = "thin"
 codegen-units = 1
 incremental = false
+# Drops debug info and the symbol table from shipped binaries (~32% smaller
+# Android .so, see issue #169). Panic messages still work; only Rust-side
+# stack traces in crash reports are lost.
+strip = "symbols"
 
 # build all our deps in release mode 
 [profile.dev.package."*"]


### PR DESCRIPTION
Adds `strip = "symbols"` to `[profile.release]`, per the benchmarks in #169: **−31.6%** on the Android arm64 `.so` (446,072 → 305,176 bytes) with no measurable compile-time cost, since stripping is a post-link step.

The other two candidates from #169 were measured and rejected there: fat LTO produced byte-identical output (`codegen-units = 1` already reaches the same fixed point), and `panic = "abort"` saved only ~1 KB.

**Wasm is exempted** via `.cargo/config.toml` (`-C strip=none` for `wasm32-unknown-unknown`): on wasm, `-C strip` removes *all* custom sections, including `target_features`, which wasm-opt needs to validate post-MVP features like bulk memory — without it, `wasm-pack build` fails validation. The published pkg loses nothing from the exemption, because wasm-opt already strips debug info and names. This also required un-ignoring `.cargo` in `.gitignore` (a stale entry).

Trade-off: crash reports from shipped native binaries lose Rust-side stack traces. Panic *messages* are unaffected.

Verified: native FFI `.dylib` drops 709,744 → 567,808 bytes (`nm -a`: 2,951 → 82 symbols, exported C ABI retained); wasm builds keep their `target_features` section byte-identical to main; the downstream `blind-threshold-bls-wasm-tests` CI job passes.

Closes #169.