### PR TITLE
ffi: Make jvm the only name for the JNI feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,12 +88,12 @@ feature. They serve different consumers and are not interchangeable.
   points users at the unmerged `web-compatible` branch of
   `blind-threshold-bls-wasm` (commit `3d1013af`, October 2022), which predates
   every fix since.
-- **`jni` (`src/jni_bridge.rs`)** — a single `verify` function with no known
+- **`jvm` (`src/jni_bridge.rs`)** — a single `verify` function with no known
   consumer. Android reaches the C ABI through JNA, not through this bridge.
 
 ## Feature gating in `lib.rs`
 
-`core::cfg_select!` picks the **first** matching arm in the order wasm, jni,
+`core::cfg_select!` picks the **first** matching arm in the order wasm, jvm,
 ffi, so `--all-features` only ever compiles the wasm module. Three consequences
 worth knowing before you trust a green run:
 

--- a/crates/threshold-bls-ffi/Cargo.toml
+++ b/crates/threshold-bls-ffi/Cargo.toml
@@ -37,5 +37,6 @@ wasm = ["wasm-bindgen", "blake2", "serde"]
 # Include a panic hook for printing panic messages to the JS console.
 wasm-debug = ["wasm", "console_error_panic_hook"]
 
-jvm = ["jni"]
+# Build JNI bindings for use from the JVM
+jvm = ["dep:jni"]
 ffi = ["serde"]

--- a/crates/threshold-bls-ffi/src/lib.rs
+++ b/crates/threshold-bls-ffi/src/lib.rs
@@ -5,7 +5,7 @@ core::cfg_select! {
     feature = "wasm" => {
         pub mod wasm;
     }
-    feature = "jni" => {
+    feature = "jvm" => {
         pub mod jni_bridge;
     }
     feature = "ffi" => {

--- a/justfile
+++ b/justfile
@@ -72,7 +72,7 @@ jvm: build-docker-image
     cid=$(docker create --platform=linux/amd64 \
         -w /app/crates/threshold-bls-ffi \
         {{ image_name }} \
-        cargo build --release --features=jni)
+        cargo build --release --features=jvm)
     trap 'docker rm -f "$cid" >/dev/null' EXIT
     docker start -a "$cid"
     docker cp "$cid":/app/target/release/{{ lib_name }}.so {{ output_dir }}/jvm/


### PR DESCRIPTION
The crate had two ways to enable the JNI bridge: the declared `jvm` feature, and
the implicit feature Cargo derives from the optional `jni` dependency. `lib.rs`
and the justfile both used the implicit one, which left `jvm` dead.

Rather than drop `jvm`, this keeps it as the only name — feature names then
describe the consumer surface throughout, matching `wasm` and `ffi`. Switching
to `dep:jni` is what suppresses the implicit feature, so there is no longer a
second way in.

- `crates/threshold-bls-ffi/Cargo.toml` — `jvm = ["jni"]` becomes `jvm = ["dep:jni"]`
- `crates/threshold-bls-ffi/src/lib.rs` — gate on `feature = "jvm"`
- `justfile` — the `jvm` recipe builds `--features=jvm`
- `CLAUDE.md` — the two lines that named the feature `jni`

The `just jvm` recipe, `output/jvm`, and the CircleCI `build-jvm` job reference
the recipe and output directory, not the feature, so they are unchanged.

## Verifying

`cargo clippy --all-features` never reaches `jni_bridge.rs`, because
`cfg_select!` matches `wasm` first, so the jvm surface was linted explicitly.

| Check | Result |
| --- | --- |
| `cargo build -p threshold-bls-ffi --no-default-features --features jvm` | compiles `jni_bridge`, pulls `jni v0.22.4` |
| `cargo build ... --features jni` | errors; Cargo's message points at `jvm` |
| `cargo test --workspace --all-features` | 35 + 2 + 7 passed, 0 failed |
| `cargo test -p threshold-bls-ffi --no-default-features --features ffi` | 4 passed |
| `cargo clippy -p threshold-bls-ffi --no-default-features --features jvm --all-targets` | clean |
| `just lint`, `just fmt` | clean |

## For a reviewer

`--features jni` is now a hard error. Every caller in this repo is updated, and
the mobile consumers link the C ABI through the justfile or the released
artifacts, so nothing here regresses. If `threshold-bls-ffi` is published
anywhere I have not checked, this breaks direct dependents and wants a version
bump — worth a second pair of eyes.

Unchanged by this PR: `jni_bridge.rs` is still the single `verify` function with
no known consumer that CLAUDE.md describes. This makes its feature name
coherent; whether the bridge should exist is a separate decision.