### PR TITLE
all: Remove dead code and unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,15 +205,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
-name = "blake2"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
-dependencies = [
- "digest",
-]
-
-[[package]]
 name = "blake2s_simd"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,15 +213,6 @@ dependencies = [
  "arrayref",
  "arrayvec",
  "constant_time_eq",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -339,9 +321,7 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
  "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -1045,12 +1025,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
 name = "syn"
 version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1139,7 +1113,6 @@ name = "threshold-bls-ffi"
 version = "0.2.0"
 dependencies = [
  "bincode",
- "blake2",
  "console_error_panic_hook",
  "getrandom 0.2.17",
  "jni",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,6 @@ incremental = false
 [profile.dev.package."*"]
 opt-level = 3
 
-[profile.bench]
-opt-level = 3
-debug = false
-rpath = false
-lto = "thin"
-incremental = true
-debug-assertions = false
-
-
 [profile.test]
 opt-level = 3
 incremental = true

--- a/crates/threshold-bls-ffi/Cargo.toml
+++ b/crates/threshold-bls-ffi/Cargo.toml
@@ -14,13 +14,13 @@ threshold-bls = { path = "../threshold-bls", default-features = false }
 rand_core = { version = "0.6.4", default-features = false }
 rand_chacha = { version = "0.3.1", default-features = false }
 
-# Required for WASM interface
 bincode = { version = "1.2.1", default-features = false }
 serde = { version = "1", default-features = false, optional = true }
 
-# Required for WASM interface
-blake2 = { version = "0.10", default-features = false, optional = true }
-getrandom = { version = "0.2", default-features = false, features = ["js"] }
+# No code here calls getrandom; `rand` pulls it in. It is listed so the wasm
+# build can enable the "js" feature, without which getrandom refuses to
+# compile for wasm32-unknown-unknown.
+getrandom = { version = "0.2", default-features = false, features = ["js"], optional = true }
 wasm-bindgen = { version = "0.2.62", optional = true }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
@@ -33,7 +33,7 @@ jni = { version = "0.22.4", optional = true }
 
 [features]
 # Build WASM bindings for use in JS environments
-wasm = ["wasm-bindgen", "blake2", "serde"]
+wasm = ["wasm-bindgen", "dep:getrandom"]
 # Include a panic hook for printing panic messages to the JS console.
 wasm-debug = ["wasm", "console_error_panic_hook"]
 

--- a/crates/threshold-bls/Cargo.toml
+++ b/crates/threshold-bls/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 crate-type = ["lib"]
 
 [dependencies]
-rand_chacha = "0.3"
 rand_core = { version = "0.6", default-features = false }
 rand = "0.8"
 serde = {version = "1", features = ["derive"] }
@@ -24,5 +23,6 @@ bincode = "1.2"
 
 [dev-dependencies]
 proptest = "1.0.0"
+rand_chacha = "0.3"
 static_assertions = "1.1.0"
 hex = "0.4.3"

--- a/crates/threshold-bls/src/curve/bls12377.rs
+++ b/crates/threshold-bls/src/curve/bls12377.rs
@@ -1,4 +1,4 @@
-use crate::group::{self, Element, PairingCurve as PC, Point, PrimeOrder, Scalar as Sc};
+use crate::group::{self, Element, PairingCurve as PC, Point, Scalar as Sc};
 
 use ark_bls12_377 as bls377;
 use ark_ec::{
@@ -367,15 +367,6 @@ impl Element for GT {
     }
     fn rand<R: RngCore>(rng: &mut R) -> Self {
         Self(bls377::Fq12::rand(rng))
-    }
-}
-
-// TODO (michael): Write unit test for this
-impl PrimeOrder for GT {
-    fn in_correct_subgroup(&self) -> bool {
-        self.0
-            .pow(<bls377::Bls12_377 as Pairing>::ScalarField::characteristic())
-            .is_one()
     }
 }
 

--- a/crates/threshold-bls/src/group.rs
+++ b/crates/threshold-bls/src/group.rs
@@ -36,13 +36,6 @@ pub trait Element:
     }
 }
 
-/// Checks inclusion in prime order subgroup. Only needed when underlying trait
-/// does not enforce this already
-pub trait PrimeOrder: Element {
-    /// Checks the provided element is in the correct prime-order subgroup
-    fn in_correct_subgroup(&self) -> bool;
-}
-
 /// Scalar can be multiplied by only a Scalar, no other elements.
 pub trait Scalar: Element {
     fn set_int(&mut self, i: u64);


### PR DESCRIPTION
Closes the dead-code half of §13 of `audits/maintainability-review-2026-07-29.md`. Four independent commits, no behaviour change: 59 lines deleted, 7 added, and `blake2`, `block-buffer` and `subtle` drop out of the lockfile.

- **`PrimeOrder`** — nothing called `in_correct_subgroup`. Its one implementation, on `GT`, was never unit tested.
- **`blake2` and `serde`** — named by the `wasm` feature, imported by no wasm code.
- **`getrandom`** — kept, made optional, and reached only through the `wasm` feature.
- **`rand_chacha`** — moved to `[dev-dependencies]` in `threshold-bls`; only `src/test_vectors.rs` uses it and that module is `#[cfg(test)]`. It has to stay listed, because `rand`'s copy is a private dependency and the tests name `ChaChaRng` directly.
- **`[profile.bench]`** — no `benches/`, no `[[bench]]` target, no `#[bench]` function anywhere in the workspace.

## Two corrections to the review

**`getrandom` cannot be deleted, only gated.** The review reads it as simply unused. Removing it fails the build with getrandom's own `compile_error!`: *"the wasm\*-unknown-unknown targets are not supported by default, you may need to enable the \"js\" feature"*. It reaches the graph via `rand`, so the entry exists solely to select a backend. The review's real point stands — it was non-optional, so every android/iOS/jvm build enabled `js` for nothing. `cargo tree -e features` now shows `getrandom feature \"js\"` absent from the `ffi` build and present in the `wasm` one. A comment in the manifest records why an uncalled dependency is listed at all.

**`PrimeOrder` was not "exactly the check §0a needs".** `x^p == 1` answers `true` for the identity element, which is the key the zero-key forgery uses, and it was implemented on `GT` rather than on the groups public keys live in. Whoever fixes the identity-key forgery writes a fresh check either way; this deletes nothing that fix could have used.

## Verification

`cargo test --workspace --all-features` (35 + 6 + 7 doctests), each surface alone (`ffi` 4 tests, `wasm` 2, `jvm` 0), `just lint`, `just fmt`, `cargo build` for `wasm32-unknown-unknown`, `cargo check` for `aarch64-apple-ios`, and `wasm-pack build --target nodejs -- --features=wasm` producing a complete pkg. A grep for stale references to the removed names comes back empty.

Not verified locally: the built wasm pkg was not executed — no node runtime on this machine, so that rests on the `blind-threshold-bls-wasm-tests` job. iOS `cargo build` fails at the link step for want of full Xcode, a pre-existing local limit, so compilation was checked with `cargo check`.

## Out of scope

The release-hygiene half of §13 (package metadata, MSRV, zeroization, CHANGELOG) is untouched. Note that removing `pub trait PrimeOrder` is a semver break for `threshold-bls`, which is on crates.io at 0.2.0, so a version bump belongs with that work. `wasm-debug` and `console_error_panic_hook` are also left alone deliberately, though the feature still enables a crate nothing calls.