### PR TITLE
build: Add package metadata to the manifests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,14 @@ members = [
     "crates/threshold-bls-ffi",
 ]
 
+# Fields shared by both crates. `rust-version` tracks the toolchain pinned in
+# rust-toolchain.toml, which is the only version the builds are tested against.
+[workspace.package]
+edition = "2021"
+rust-version = "1.95"
+license = "Apache-2.0"
+repository = "https://github.com/celo-org/celo-threshold-bls-rs"
+
 [profile.release]
 opt-level = 3
 lto = "thin"

--- a/crates/threshold-bls-ffi/Cargo.toml
+++ b/crates/threshold-bls-ffi/Cargo.toml
@@ -2,7 +2,14 @@
 name = "threshold-bls-ffi"
 version = "0.2.0"
 authors = ["Georgios Konstantopoulos <me@gakonst.com>", "Paul Lange <palango@gmx.de>"]
-edition = "2021"
+description = "C, WASM and JNI bindings for threshold BLS signatures over BLS12-377"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+# Consumers link the prebuilt artifacts (npm package, JNA, static libs), not a
+# crates.io release, so the path dependency below needs no version.
+publish = false
 
 [lib]
 crate-type = ["lib", "cdylib", "staticlib"]

--- a/crates/threshold-bls/Cargo.toml
+++ b/crates/threshold-bls/Cargo.toml
@@ -2,7 +2,13 @@
 name = "threshold-bls"
 version = "0.2.0"
 authors = ["nikkolasg", "Paul Lange <palango@gmx.de>"]
-edition = "2021"
+description = "Threshold BLS signatures over BLS12-377, with blind signing"
+keywords = ["bls", "threshold", "signature", "blind-signature", "crypto"]
+categories = ["cryptography"]
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [lib]
 crate-type = ["lib"]


### PR DESCRIPTION
Neither crate declared a `license`, `repository`, `description` or MSRV. `threshold-bls@0.2.0` is on crates.io with no license at all, despite the Apache-2.0 `LICENSE` in this repo.

Shared fields (`edition`, `rust-version`, `license`, `repository`) go in `[workspace.package]` and both crates inherit them. `rust-version = "1.95"` deliberately tracks the `rust-toolchain.toml` pin rather than a bisected true floor — 1.95 is the only version these builds are tested against, so claiming anything lower would be a guess.

`threshold-bls-ffi` is marked `publish = false`: its consumers link the prebuilt npm/JNA/static artifacts, not a crates.io release. That turns its versionless path dependency from an accident into a stated choice.

Verified: `cargo test --workspace --all-features` (48 tests + doctests) pass, `cargo clippy --all-targets --all-features -- -D warnings` clean, `cargo fmt --check` clean, `cargo package -p threshold-bls` succeeds, `cargo publish -p threshold-bls-ffi --dry-run` refuses on the `publish = false` flag.

One pre-existing wart this does not fix: `cargo package --workspace` does not honour `publish = false` and still fails on the ffi crate's path dep. It fails identically on `main`.