### PR TITLE
sig: Reject identity points in verification

### DIFF
--- a/crates/threshold-bls-ffi/src/ffi.rs
+++ b/crates/threshold-bls-ffi/src/ffi.rs
@@ -914,4 +914,27 @@ mod tests {
 
         assert_eq!(public_key, unsafe { &*de });
     }
+
+    /// The identity is a well-formed encoding, so it still deserializes — the
+    /// C ABI's existing guards only cover malformed input. Verification is what
+    /// has to reject it.
+    #[test]
+    fn identity_public_key_verifies_nothing() {
+        use threshold_bls::group::Element;
+
+        let identity = bincode::serialize(&PublicKey::new()).unwrap();
+        assert_eq!(identity.len(), PUBKEY_LEN);
+
+        let mut pubkey = MaybeUninit::<*mut PublicKey>::uninit();
+        let ret = unsafe { deserialize_pubkey(&identity[0] as *const u8, pubkey.as_mut_ptr()) };
+        assert!(ret, "the identity encoding is well-formed");
+        let pubkey = unsafe { pubkey.assume_init() };
+
+        let identity_sig = bincode::serialize(&Signature::new()).unwrap();
+        for msg in [&b"attack at dawn"[..], b"totally different", b""] {
+            let ret =
+                unsafe { verify(pubkey, &Buffer::from(msg), &Buffer::from(&identity_sig[..])) };
+            assert!(!ret, "identity public key verified {msg:?}");
+        }
+    }
 }

--- a/crates/threshold-bls/src/poly.rs
+++ b/crates/threshold-bls/src/poly.rs
@@ -108,7 +108,8 @@ where
         // +1 because we must never evaluate the polynomial at its first point
         // otherwise it reveals the "secret" value !
         // TODO: maybe move that a layer above, to not mix ss scheme with poly.
-        xi.set_int((i + 1).into());
+        // Widened to u64 so the largest index cannot wrap back onto x = 0.
+        xi.set_int(u64::from(i) + 1);
 
         let res = self.0.iter().rev().fold(C::zero(), |mut sum, coeff| {
             sum.mul(&xi);
@@ -211,7 +212,9 @@ where
             .take(t)
             .fold(BTreeMap::new(), |mut m, sh| {
                 let mut xi = C::RHS::new();
-                xi.set_int((sh.index + 1).into());
+                // Widened to u64 so the largest index cannot wrap back onto
+                // x = 0, where it would annihilate every other Lagrange term.
+                xi.set_int(u64::from(sh.index) + 1);
                 m.insert(sh.index, (xi, sh.value));
                 m
             });
@@ -359,6 +362,50 @@ pub mod tests {
         let p = Poly::<Sc>::new(s);
         assert_eq!(p.0.len(), s + 1);
         assert_eq!(p.degree(), s);
+    }
+
+    /// Evaluating at the largest index must not collapse onto the constant
+    /// term. `eval` shifts the index by one to avoid handing out the secret at
+    /// x = 0, and that shift must hold across the whole index range.
+    #[test]
+    fn eval_at_max_index_does_not_reveal_the_constant_term() {
+        let private = Poly::<Sc>::new(3);
+        let at_max = private.eval(Idx::MAX);
+        assert_ne!(
+            &at_max.value,
+            private.public_key(),
+            "eval(Idx::MAX) returned the constant term"
+        );
+    }
+
+    /// A share at the largest index must not be able to displace the honest
+    /// shares. If its x collapses to zero, every other Lagrange numerator picks
+    /// up that zero factor and the attacker's value is recovered verbatim.
+    #[test]
+    fn recover_is_not_hijacked_by_max_index_share() {
+        let t = 3;
+        let private = Poly::<Sc>::new(t - 1);
+        let secret = *private.public_key();
+
+        let mut shares: Vec<Eval<Sc>> = (0..t as Idx).map(|i| private.eval(i)).collect();
+
+        // The attacker replaces one honest share with an arbitrary value
+        // labelled with the largest index.
+        let attacker_value = Sc::rand(&mut thread_rng());
+        shares[t - 1] = Eval {
+            index: Idx::MAX,
+            value: attacker_value,
+        };
+
+        let recovered = Poly::<Sc>::recover(t, shares).expect("recovery should not error");
+        assert_ne!(
+            recovered, attacker_value,
+            "a single share at Idx::MAX overrode every honest share"
+        );
+        assert_ne!(
+            recovered, secret,
+            "recovery from a tampered share should not yield the secret"
+        );
     }
 
     #[test]

--- a/crates/threshold-bls/src/poly.rs
+++ b/crates/threshold-bls/src/poly.rs
@@ -408,6 +408,20 @@ pub mod tests {
         );
     }
 
+    /// The largest index is an ordinary evaluation point, not a special case:
+    /// an honest share dealt there must interpolate like any other. This is the
+    /// half that a fix clamping or rejecting `Idx::MAX` would fail.
+    #[test]
+    fn recover_works_with_a_share_at_the_max_index() {
+        let t = 3;
+        let private = Poly::<Sc>::new(t - 1);
+
+        let shares = vec![private.eval(0), private.eval(1), private.eval(Idx::MAX)];
+
+        let recovered = Poly::<Sc>::recover(t, shares).expect("recovery should not error");
+        assert_eq!(&recovered, private.public_key());
+    }
+
     #[test]
     fn add_zero() {
         let p1 = Poly::<Sc>::new(3);

--- a/crates/threshold-bls/src/sig/blind.rs
+++ b/crates/threshold-bls/src/sig/blind.rs
@@ -88,10 +88,7 @@ where
         // signature point
         let blinded_sig: I::Signature = serialization::deserialize(blinded_sig)?;
 
-        if !I::final_exp(public, &blinded_sig, &blinded_msg) {
-            return Err(BlindError::from(BLSError::InvalidSig));
-        }
-        Ok(())
+        I::check_pairing(public, &blinded_sig, &blinded_msg).map_err(BlindError::from)
     }
 
     fn blind_sign(private: &I::Private, blinded_msg: &[u8]) -> Result<Vec<u8>, Self::Error> {
@@ -135,5 +132,41 @@ mod tests {
 
         let clear_sig = B::unblind_sig(&token, &blinded_sig).expect("unblind should go well");
         B::verify(&public, &msg, &clear_sig).unwrap();
+    }
+
+    #[test]
+    fn blind_identity_g1() {
+        identity_operands_rejected::<G1Scheme<PCurve>>();
+    }
+
+    #[test]
+    fn blind_identity_g2() {
+        identity_operands_rejected::<G2Scheme<PCurve>>();
+    }
+
+    /// Unlike plain BLS, `blind_verify` takes the message point from the wire
+    /// rather than from `hash_to_curve`. An identity there pairs to 1 on both
+    /// sides, so it would otherwise verify under *any* public key, including
+    /// honest ones.
+    fn identity_operands_rejected<B>()
+    where
+        B: BlindScheme<Error = BlindError>,
+    {
+        let (_, public) = B::keypair(&mut thread_rng());
+        let identity = bincode::serialize(&B::Signature::new()).unwrap();
+        let (_, blinded_msg) = B::blind_msg(&[1, 9, 6, 9], &mut thread_rng());
+
+        assert!(
+            matches!(
+                B::blind_verify(&public, &identity, &identity),
+                Err(BlindError::SignatureError(BLSError::InvalidMessagePoint))
+            ),
+            "identity blinded message forged a signature under an honest key"
+        );
+
+        assert!(matches!(
+            B::blind_verify(&B::Public::new(), &blinded_msg, &identity),
+            Err(BlindError::SignatureError(BLSError::InvalidPublicKey))
+        ));
     }
 }

--- a/crates/threshold-bls/src/sig/bls.rs
+++ b/crates/threshold-bls/src/sig/bls.rs
@@ -13,12 +13,12 @@ pub enum BLSError {
     InvalidSig,
 
     /// InvalidPublicKey is raised when the public key is the identity element,
-    /// which would verify every message.
+    /// which would accept an identity signature on any message.
     #[error("public key is the identity element")]
     InvalidPublicKey,
 
     /// InvalidMessagePoint is raised when the message point is the identity
-    /// element, which would be verified by every public key.
+    /// element, which would let an identity signature verify under any key.
     #[error("message point is the identity element")]
     InvalidMessagePoint,
 
@@ -80,16 +80,16 @@ pub mod common {
 
         /// Rejects degenerate operands and then checks the pairing equation.
         ///
-        /// The pairing equation holds for every message once either the public
-        /// key or the message point is the identity, since both sides of
-        /// `e(sig, g2) == e(hm, pub)` collapse to 1. Rejecting the identity
-        /// public key is the IETF BLS spec's `KeyValidate`; the message point
-        /// needs the same treatment because the blind scheme takes it from the
-        /// wire rather than from `hash_to_curve`.
+        /// An identity public key makes one side of `e(sig, g2) == e(hm, pub)`
+        /// equal to 1 for every message, so it accepts the identity signature
+        /// on anything. An identity message point does the same, and the blind
+        /// scheme takes that point from the wire rather than from
+        /// `hash_to_curve`, so it needs the same treatment. Rejecting the
+        /// identity public key is the IETF BLS spec's `KeyValidate`.
         ///
-        /// The signature is deliberately not checked: an identity signature
-        /// cannot satisfy the equation against a non-identity public key, and
-        /// aggregation may legitimately produce one.
+        /// The signature itself is deliberately not checked: on its own it
+        /// only fails the equation, and aggregation may legitimately produce
+        /// it.
         fn check_pairing(
             public: &Self::Public,
             sig: &Self::Signature,
@@ -281,10 +281,10 @@ mod tests {
         ));
     }
 
-    /// The pairing equation is what makes the identity dangerous: with either
-    /// operand the identity, both sides are 1 and it holds for every message.
-    /// `check_pairing` is the only thing standing between that and a forgery,
-    /// so pin the degeneracy — the tests above are vacuous without it.
+    /// Pins the degeneracy the guard exists for: an identity public key, or an
+    /// identity message point, satisfies the raw equation against an identity
+    /// signature for any message. Were that to stop holding, the rejection
+    /// tests above would keep passing while proving nothing.
     fn pairing_is_degenerate_on_identity<S>()
     where
         S: common::BLSScheme,

--- a/crates/threshold-bls/src/sig/bls.rs
+++ b/crates/threshold-bls/src/sig/bls.rs
@@ -12,6 +12,16 @@ pub enum BLSError {
     #[error("invalid signature")]
     InvalidSig,
 
+    /// InvalidPublicKey is raised when the public key is the identity element,
+    /// which would verify every message.
+    #[error("public key is the identity element")]
+    InvalidPublicKey,
+
+    /// InvalidMessagePoint is raised when the message point is the identity
+    /// element, which would be verified by every public key.
+    #[error("message point is the identity element")]
+    InvalidMessagePoint,
+
     #[error("could not hash to curve")]
     HashingError,
 
@@ -65,8 +75,35 @@ pub mod common {
                 serialization::deserialize_from(msg)?
             };
 
-            let success = Self::final_exp(public, &sig, &h);
-            if !success {
+            Self::check_pairing(public, &sig, &h)
+        }
+
+        /// Rejects degenerate operands and then checks the pairing equation.
+        ///
+        /// The pairing equation holds for every message once either the public
+        /// key or the message point is the identity, since both sides of
+        /// `e(sig, g2) == e(hm, pub)` collapse to 1. Rejecting the identity
+        /// public key is the IETF BLS spec's `KeyValidate`; the message point
+        /// needs the same treatment because the blind scheme takes it from the
+        /// wire rather than from `hash_to_curve`.
+        ///
+        /// The signature is deliberately not checked: an identity signature
+        /// cannot satisfy the equation against a non-identity public key, and
+        /// aggregation may legitimately produce one.
+        fn check_pairing(
+            public: &Self::Public,
+            sig: &Self::Signature,
+            hm: &Self::Signature,
+        ) -> Result<(), BLSError> {
+            if public == &Self::Public::new() {
+                return Err(BLSError::InvalidPublicKey);
+            }
+
+            if hm == &Self::Signature::new() {
+                return Err(BLSError::InvalidMessagePoint);
+            }
+
+            if !Self::final_exp(public, sig, hm) {
                 return Err(BLSError::InvalidSig);
             }
 
@@ -184,5 +221,100 @@ mod tests {
         let msg = vec![1, 9, 6, 9];
         let sig = G1Scheme::<PCurve>::sign(&private, &msg).unwrap();
         G1Scheme::<PCurve>::verify(&public, &msg, &sig).expect("that should not happen");
+    }
+
+    /// The identity public key satisfies `e(sig, g2) == e(H(m), pub)` for every
+    /// message, so an identity signature under it would otherwise verify
+    /// anything. The encoding itself stays legal — only verification rejects it.
+    fn identity_key_verifies_nothing<S>(pubkey_len: usize)
+    where
+        S: SignatureScheme<Error = BLSError>,
+    {
+        let identity_sig = bincode::serialize(&S::Signature::new()).unwrap();
+
+        let encoded = bincode::serialize(&S::Public::new()).unwrap();
+        assert_eq!(encoded.len(), pubkey_len);
+        assert_eq!(
+            encoded.last(),
+            Some(&0x40),
+            "the identity encodes as the point-at-infinity flag"
+        );
+
+        let identity: S::Public = serialization::deserialize(&encoded).unwrap();
+        assert_eq!(
+            identity,
+            S::Public::new(),
+            "the identity must stay deserializable"
+        );
+
+        for msg in [&b"attack at dawn"[..], b"totally different", b""] {
+            assert!(
+                matches!(
+                    S::verify(&identity, msg, &identity_sig),
+                    Err(BLSError::InvalidPublicKey)
+                ),
+                "identity public key verified {msg:?}"
+            );
+        }
+    }
+
+    /// An identity signature is a bad signature rather than a rejected one: the
+    /// IETF spec subgroup-checks signatures but never rejects the identity,
+    /// since aggregation can legitimately produce it.
+    fn identity_signature_is_merely_invalid<S>()
+    where
+        S: SignatureScheme<Error = BLSError>,
+    {
+        let (private, public) = S::keypair(&mut thread_rng());
+        let msg = b"attack at dawn";
+
+        let identity_sig = bincode::serialize(&S::Signature::new()).unwrap();
+        assert!(matches!(
+            S::verify(&public, msg, &identity_sig),
+            Err(BLSError::InvalidSig)
+        ));
+
+        let sig = S::sign(&private, msg).unwrap();
+        assert!(matches!(
+            S::verify(&S::Public::new(), msg, &sig),
+            Err(BLSError::InvalidPublicKey)
+        ));
+    }
+
+    /// The pairing equation is what makes the identity dangerous: with either
+    /// operand the identity, both sides are 1 and it holds for every message.
+    /// `check_pairing` is the only thing standing between that and a forgery,
+    /// so pin the degeneracy — the tests above are vacuous without it.
+    fn pairing_is_degenerate_on_identity<S>()
+    where
+        S: common::BLSScheme,
+    {
+        let mut hm = S::Signature::new();
+        hm.map(b"attack at dawn").expect("could not hash to curve");
+
+        assert!(
+            S::final_exp(&S::Public::new(), &S::Signature::new(), &hm),
+            "identity public key should satisfy the raw pairing equation"
+        );
+
+        let (_, public) = S::keypair(&mut thread_rng());
+        assert!(
+            S::final_exp(&public, &S::Signature::new(), &S::Signature::new()),
+            "identity message point should satisfy the raw pairing equation"
+        );
+    }
+
+    #[test]
+    fn identity_g1() {
+        pairing_is_degenerate_on_identity::<G1Scheme<PCurve>>();
+        identity_key_verifies_nothing::<G1Scheme<PCurve>>(48);
+        identity_signature_is_merely_invalid::<G1Scheme<PCurve>>();
+    }
+
+    #[test]
+    fn identity_g2() {
+        pairing_is_degenerate_on_identity::<G2Scheme<PCurve>>();
+        identity_key_verifies_nothing::<G2Scheme<PCurve>>(96);
+        identity_signature_is_merely_invalid::<G2Scheme<PCurve>>();
     }
 }

--- a/crates/threshold-bls/src/sig/tblind.rs
+++ b/crates/threshold-bls/src/sig/tblind.rs
@@ -68,11 +68,13 @@ where
 mod tests {
     use super::*;
     use crate::curve::bls12377::PairingCurve as PCurve;
+    use crate::group::Element;
     use crate::poly::{Idx, Poly};
     use crate::sig::{
-        bls::{G1Scheme, G2Scheme},
+        blind::BlindError,
+        bls::{BLSError, G1Scheme, G2Scheme},
         tbls::Share,
-        SignatureScheme,
+        BlindScheme, SignatureScheme,
     };
     use rand::thread_rng;
 
@@ -144,5 +146,43 @@ mod tests {
         // verify the final signature
         B::verify(public.public_key(), &msg, &final_sig2).unwrap();
         assert_eq!(final_sig1, final_sig2);
+    }
+
+    #[test]
+    fn tblind_identity_g1() {
+        identity_operands_rejected::<G1Scheme<PCurve>>();
+    }
+
+    #[test]
+    fn tblind_identity_g2() {
+        identity_operands_rejected::<G2Scheme<PCurve>>();
+    }
+
+    /// `verify_blind_partial` takes the blinded message, the partial signature
+    /// and the index from the wire. An identity blinded message would otherwise
+    /// pass against an honest public polynomial at any index.
+    fn identity_operands_rejected<B>()
+    where
+        B: BlindThresholdScheme<Error = BlindThresholdError<BlindError>>
+            + BlindScheme<Error = BlindError>
+            + ThresholdScheme,
+    {
+        let (_, public) = shares::<B>(5, 4);
+        let identity = bincode::serialize(&B::Signature::new()).unwrap();
+        let partial = bincode::serialize(&Eval {
+            index: 1,
+            value: identity.clone(),
+        })
+        .unwrap();
+
+        assert!(
+            matches!(
+                B::verify_blind_partial(&public, &identity, &partial),
+                Err(BlindThresholdError::BlindError(BlindError::SignatureError(
+                    BLSError::InvalidMessagePoint
+                )))
+            ),
+            "identity blinded message forged a partial under an honest polynomial"
+        );
     }
 }

--- a/crates/threshold-bls/src/sig/tbls.rs
+++ b/crates/threshold-bls/src/sig/tbls.rs
@@ -98,8 +98,9 @@ mod tests {
     use super::*;
     use crate::{
         curve::bls12377::PairingCurve as PCurve,
+        group::Element,
         sig::{
-            bls::{G1Scheme, G2Scheme},
+            bls::{BLSError, G1Scheme, G2Scheme},
             Scheme, SignatureScheme,
         },
     };
@@ -152,5 +153,36 @@ mod tests {
     fn threshold_g2() {
         type S = G2Scheme<PCurve>;
         test_threshold_scheme::<S>(shares::<S>);
+    }
+
+    #[test]
+    fn empty_polynomial_verifies_nothing_g1() {
+        empty_polynomial_verifies_nothing::<G1Scheme<PCurve>>();
+    }
+
+    #[test]
+    fn empty_polynomial_verifies_nothing_g2() {
+        empty_polynomial_verifies_nothing::<G2Scheme<PCurve>>();
+    }
+
+    /// A public polynomial with no coefficients is a bare length prefix on the
+    /// wire, and evaluates to the identity at every index. Rejecting the
+    /// identity public key is what stops it standing in for a real key.
+    fn empty_polynomial_verifies_nothing<T>()
+    where
+        T: SignatureScheme<Error = BLSError> + ThresholdScheme<Error = ThresholdError<T>>,
+    {
+        let empty: Poly<T::Public> = serialization::deserialize(&[0u8; 8]).unwrap();
+
+        let partial = bincode::serialize(&Eval {
+            index: 7,
+            value: bincode::serialize(&<T as Scheme>::Signature::new()).unwrap(),
+        })
+        .unwrap();
+
+        assert!(matches!(
+            T::partial_verify(&empty, b"any message at all", &partial),
+            Err(ThresholdError::SignatureError(BLSError::InvalidPublicKey))
+        ));
     }
 }


### PR DESCRIPTION
Closes the identity-point findings: `audits/fable.md` #4, restated as §0a of the
2026-07-29 maintainability review. Both were live on `main` and reachable from
all three binding surfaces.

## The defects

An identity public key makes one side of `e(sig, g2) == e(hm, pub)` equal to 1
for every message, so it accepts the identity signature on anything —
`verify(identity_pk, <any message>, identity_sig)` returned `Ok`.

The blind path is worse, and it is the part a spec-literal fix would have
missed. `blind_verify` deserializes the *message* point from the wire rather
than computing it with `hash_to_curve`, so an identity there verifies under
**any** public key, honest ones included:
`blind_verify(honest_pk, identity_msg, identity_sig)` returned `Ok`. That
forgery never touches the public key, so rejecting only the key would have left
it live.

Two consequences fall out for free: an empty `Poly<PublicKey>` deserializes
from eight zero bytes and evaluates to the identity at every index, and
`aggregate(0, &[])`'s identity output can no longer chain into a complete
forgery.

## The fix

A provided method `common::BLSScheme::check_pairing` rejects an identity public
key (`InvalidPublicKey`) and an identity message point (`InvalidMessagePoint`)
before calling `final_exp`. Both `internal_verify` and `blind_verify` route
through it, so `partial_verify` and `verify_blind_partial` inherit it and a
future curve implementation cannot forget it.

**Signatures are deliberately not checked.** IETF draft-irtf-cfrg-bls-signature
§2.5 rejects the identity for public keys only; signatures get a subgroup check
because aggregation can legitimately produce the identity, and Ethereum's
Altair `eth_fast_aggregate_verify` explicitly accepts the infinity signature.
An identity signature under a validated key simply fails the equation.

**The wire format is unchanged.** The compressed identity still deserializes,
matching the spec and Ethereum's `deserialization_succeeds_infinity_with_true_b_flag`
vector; only verification rejects it. The `test_vectors` regression tests pass
untouched.

### Why not in `deserialize_group`

One rejection at the byte→point chokepoint would close every path at once, but
it is role-blind: `G1Scheme` and `G2Scheme` swap which group holds keys, so the
same type serves as both key and signature. It would blanket-reject identity
signatures, against the spec. No surveyed library rejects the identity in a
shared group-point decoder. `PrimeOrder::in_correct_subgroup` was no help
either and is already deleted — it computed `x^p == 1`, which answers `true`
for the identity.

Arkworks cannot help: the infinity flag short-circuits at
`ark-ec-0.6.0/.../short_weierstrass/mod.rs:184` and returns `Affine::identity()`
*before* `check()` runs, in every version 0.3–0.6. There is no `Validate` mode
that refuses it.

## Third commit: the `Idx::MAX` wrap

Separable from the identity work; drop it if you would rather it landed alone.

`Poly::eval` and `share_map` computed `index + 1` in `u32`, which wrapped to
zero at `Idx::MAX` — the one point the shift exists to avoid. Reproduced in
release before the fix: `eval(Idx::MAX)` returned the constant term verbatim,
and in `recover` a share at that index annihilated every other Lagrange
numerator so its value was recovered in place of the honest shares. Debug
builds panicked on the same caller-supplied index. `set_int` already takes a
`u64`, so widening the addition removes the wrap without moving the point any
valid index maps to.

## Verification

- `cargo test --workspace --all-features` — 45 + 7 + 7 doctests, green
- Same in `--release`: the `Idx::MAX` behaviour differs by profile, since
  `[profile.test]` sets `debug-assertions = true`
- `cargo test -p threshold-bls-ffi --no-default-features --features ffi` — green
- `just lint`, `just fmt` — clean

Ten new tests across both curve orientations at four layers plus the C ABI.
`pairing_is_degenerate_on_identity` asserts the raw pairing *does* accept
identity operands, so the rejection tests cannot pass vacuously; the two
`Idx::MAX` tests failed in both profiles before the third commit.

## Known gaps

- **No wasm negative test.** `wasm.rs` error paths return `JsValue`, and
  `JsValue::from_str` aborts non-unwindingly under native `cargo test`. The
  surface inherits the fix through `SigScheme::verify` and holds no
  verification logic of its own, but testing it needs the `try_*`/`Result<_,
  String>` split.
- **Not exploitable against ODIS**, checked before opening this: every key
  there is pinned (SDK constants, combiner env config), and the identity
  signature fails the client's final `verify`, which hashes the plaintext
  itself. This is a correctness and defence-in-depth fix, not an incident.
- **Still open:** duplicate share indices in `share_map` (dedup happens after
  `take(t)`), and `aggregate(0, &[])` returning `Ok`.