### PR TITLE
sig: Reject zero thresholds and duplicate share indices in aggregation

### DIFF
--- a/crates/threshold-bls/src/poly.rs
+++ b/crates/threshold-bls/src/poly.rs
@@ -479,13 +479,10 @@ pub mod tests {
 
         let shares = vec![private.eval(0), private.eval(0), private.eval(1)];
 
-        match Poly::<Sc>::recover(t, shares) {
-            Err(PolyError::InvalidRecovery(distinct, threshold)) => {
-                assert_eq!(distinct, 2);
-                assert_eq!(threshold, t);
-            }
-            other => panic!("expected InvalidRecovery, got {:?}", other.map(|_| ())),
-        }
+        assert!(matches!(
+            Poly::<Sc>::recover(t, shares),
+            Err(PolyError::InvalidRecovery(2, 3))
+        ));
     }
 
     #[test]

--- a/crates/threshold-bls/src/poly.rs
+++ b/crates/threshold-bls/src/poly.rs
@@ -95,6 +95,8 @@ pub enum PolyError {
     InvalidRecovery(usize, usize),
     #[error("Could not invert scalar")]
     NoInverse,
+    #[error("Cannot recover with a threshold of zero")]
+    ZeroThreshold,
 }
 
 impl<C> Poly<C>
@@ -198,6 +200,11 @@ where
         t: usize,
         mut shares: Vec<Eval<C>>,
     ) -> Result<BTreeMap<Idx, (C::RHS, C)>, PolyError> {
+        // Interpolating over zero points would "recover" the group identity.
+        if t == 0 {
+            return Err(PolyError::ZeroThreshold);
+        }
+
         // first sort the shares as it can happens recovery happens for
         // non-correlated shares so the subset chosen becomes important
         shares.sort_by_key(|a| a.index);
@@ -427,6 +434,21 @@ pub mod tests {
         assert_eq!(&recovered, private.public_key());
     }
 
+    /// Interpolating over zero points folds to the group identity, so a
+    /// threshold of zero would "recover" a value from no shares at all. It
+    /// must be rejected, not answered.
+    #[test]
+    fn recover_rejects_a_zero_threshold() {
+        assert!(matches!(
+            Poly::<Sc>::recover(0, vec![]),
+            Err(PolyError::ZeroThreshold)
+        ));
+        assert!(matches!(
+            Poly::<Sc>::full_recover(0, vec![]),
+            Err(PolyError::ZeroThreshold)
+        ));
+    }
+
     /// A duplicated index is the same evaluation point, so it must not crowd
     /// out the other shares: as long as t distinct points remain, recovery
     /// succeeds.
@@ -533,7 +555,9 @@ pub mod tests {
 
 
     #[test]
-    fn interpolation(degree in 0..100usize, num_evals in 0..100usize) {
+    // num_evals starts at 1: recovery with a threshold of zero is rejected,
+    // covered by recover_rejects_a_zero_threshold.
+    fn interpolation(degree in 0..100usize, num_evals in 1..100usize) {
         let poly = Poly::<Sc>::new(degree);
         let expected = poly.0[0];
 

--- a/crates/threshold-bls/src/poly.rs
+++ b/crates/threshold-bls/src/poly.rs
@@ -198,13 +198,18 @@ where
         t: usize,
         mut shares: Vec<Eval<C>>,
     ) -> Result<BTreeMap<Idx, (C::RHS, C)>, PolyError> {
-        if shares.len() < t {
-            return Err(PolyError::InvalidRecovery(shares.len(), t));
-        }
-
         // first sort the shares as it can happens recovery happens for
         // non-correlated shares so the subset chosen becomes important
         shares.sort_by_key(|a| a.index);
+
+        // Duplicate indices are the same evaluation point: keep the first
+        // occurrence, then count. Deduping after choosing the subset would
+        // interpolate over fewer than t points.
+        shares.dedup_by_key(|a| a.index);
+
+        if shares.len() < t {
+            return Err(PolyError::InvalidRecovery(shares.len(), t));
+        }
 
         // convert the indexes of the shares into scalars
         let xs = shares
@@ -420,6 +425,45 @@ pub mod tests {
 
         let recovered = Poly::<Sc>::recover(t, shares).expect("recovery should not error");
         assert_eq!(&recovered, private.public_key());
+    }
+
+    /// A duplicated index is the same evaluation point, so it must not crowd
+    /// out the other shares: as long as t distinct points remain, recovery
+    /// succeeds.
+    #[test]
+    fn recover_ignores_duplicate_indices() {
+        let t = 4;
+        let private = Poly::<Sc>::new(t - 1);
+
+        let shares = vec![
+            private.eval(0),
+            private.eval(0),
+            private.eval(1),
+            private.eval(2),
+            private.eval(3),
+        ];
+
+        let recovered = Poly::<Sc>::recover(t, shares).expect("recovery should not error");
+        assert_eq!(&recovered, private.public_key());
+    }
+
+    /// Duplicates must not count towards the threshold. Interpolating over
+    /// fewer than t distinct points returns a wrong constant term, so this
+    /// input has to be rejected up front.
+    #[test]
+    fn recover_rejects_duplicates_masking_a_shortfall() {
+        let t = 3;
+        let private = Poly::<Sc>::new(t - 1);
+
+        let shares = vec![private.eval(0), private.eval(0), private.eval(1)];
+
+        match Poly::<Sc>::recover(t, shares) {
+            Err(PolyError::InvalidRecovery(distinct, threshold)) => {
+                assert_eq!(distinct, 2);
+                assert_eq!(threshold, t);
+            }
+            other => panic!("expected InvalidRecovery, got {:?}", other.map(|_| ())),
+        }
     }
 
     #[test]

--- a/crates/threshold-bls/src/sig/tbls.rs
+++ b/crates/threshold-bls/src/sig/tbls.rs
@@ -174,9 +174,9 @@ mod tests {
         aggregate_rejects_a_zero_threshold::<G2Scheme<PCurve>>();
     }
 
-    /// A threshold of zero used to pass both length guards and produce the
-    /// identity signature from an empty slice — a valid-looking signature
-    /// from no inputs at all.
+    /// Aggregating over zero partials folds to the identity signature — a
+    /// valid-looking signature from no inputs at all — so a threshold of
+    /// zero is rejected outright.
     fn aggregate_rejects_a_zero_threshold<T>()
     where
         T: ThresholdScheme<Error = ThresholdError<T>> + SignatureScheme,

--- a/crates/threshold-bls/src/sig/tbls.rs
+++ b/crates/threshold-bls/src/sig/tbls.rs
@@ -156,6 +156,68 @@ mod tests {
     }
 
     #[test]
+    fn aggregate_ignores_duplicate_partials_g1() {
+        aggregate_ignores_duplicate_partials::<G1Scheme<PCurve>>();
+    }
+
+    #[test]
+    fn aggregate_ignores_duplicate_partials_g2() {
+        aggregate_ignores_duplicate_partials::<G2Scheme<PCurve>>();
+    }
+
+    /// A partial submitted twice (e.g. by a retrying signer) is one evaluation
+    /// point, not two: aggregation succeeds as long as enough distinct
+    /// partials remain.
+    fn aggregate_ignores_duplicate_partials<T: ThresholdScheme + SignatureScheme>() {
+        let threshold = 4;
+        let (shares, public) = shares::<T>(5, threshold);
+        let msg = vec![1, 9, 6, 9];
+
+        let mut partials: Vec<_> = shares
+            .iter()
+            .map(|s| T::partial_sign(s, &msg).unwrap())
+            .collect();
+        partials.insert(0, partials[0].clone());
+        partials.truncate(5);
+
+        let final_sig = T::aggregate(threshold, &partials).unwrap();
+        T::verify(public.public_key(), &msg, &final_sig).unwrap();
+    }
+
+    #[test]
+    fn aggregate_rejects_duplicates_masking_a_shortfall_g1() {
+        aggregate_rejects_duplicates_masking_a_shortfall::<G1Scheme<PCurve>>();
+    }
+
+    #[test]
+    fn aggregate_rejects_duplicates_masking_a_shortfall_g2() {
+        aggregate_rejects_duplicates_masking_a_shortfall::<G2Scheme<PCurve>>();
+    }
+
+    /// Duplicated partials must not count towards the threshold: fewer than
+    /// threshold distinct evaluation points cannot recover the signature, and
+    /// interpolating over them anyway would return a wrong one.
+    fn aggregate_rejects_duplicates_masking_a_shortfall<T>()
+    where
+        T: ThresholdScheme<Error = ThresholdError<T>> + SignatureScheme,
+    {
+        let threshold = 4;
+        let (shares, _) = shares::<T>(5, threshold);
+        let msg = vec![1, 9, 6, 9];
+
+        let mut partials: Vec<_> = shares[..threshold - 1]
+            .iter()
+            .map(|s| T::partial_sign(s, &msg).unwrap())
+            .collect();
+        partials.insert(0, partials[0].clone());
+
+        assert!(matches!(
+            T::aggregate(threshold, &partials),
+            Err(ThresholdError::PolyError(PolyError::InvalidRecovery(3, 4)))
+        ));
+    }
+
+    #[test]
     fn empty_polynomial_verifies_nothing_g1() {
         empty_polynomial_verifies_nothing::<G1Scheme<PCurve>>();
     }

--- a/crates/threshold-bls/src/sig/tbls.rs
+++ b/crates/threshold-bls/src/sig/tbls.rs
@@ -34,6 +34,11 @@ pub enum ThresholdError<I: SignatureScheme> {
     /// were fewer than the threshold
     #[error("not enough partial signatures: {0}/{1}")]
     NotEnoughPartialSignatures(usize, usize),
+
+    /// ZeroThreshold is raised if aggregation is attempted with a threshold of
+    /// zero, which would produce a signature from no partials at all
+    #[error("threshold must be at least one")]
+    ZeroThreshold,
 }
 
 impl<I: SignatureScheme> ThresholdScheme for I {
@@ -68,6 +73,10 @@ impl<I: SignatureScheme> ThresholdScheme for I {
         threshold: usize,
         partials: &[Partial],
     ) -> Result<Vec<u8>, <Self as ThresholdScheme>::Error> {
+        if threshold == 0 {
+            return Err(ThresholdError::ZeroThreshold);
+        }
+
         if threshold > partials.len() {
             return Err(ThresholdError::NotEnoughPartialSignatures(
                 partials.len(),
@@ -153,6 +162,29 @@ mod tests {
     fn threshold_g2() {
         type S = G2Scheme<PCurve>;
         test_threshold_scheme::<S>(shares::<S>);
+    }
+
+    #[test]
+    fn aggregate_rejects_a_zero_threshold_g1() {
+        aggregate_rejects_a_zero_threshold::<G1Scheme<PCurve>>();
+    }
+
+    #[test]
+    fn aggregate_rejects_a_zero_threshold_g2() {
+        aggregate_rejects_a_zero_threshold::<G2Scheme<PCurve>>();
+    }
+
+    /// A threshold of zero used to pass both length guards and produce the
+    /// identity signature from an empty slice — a valid-looking signature
+    /// from no inputs at all.
+    fn aggregate_rejects_a_zero_threshold<T>()
+    where
+        T: ThresholdScheme<Error = ThresholdError<T>> + SignatureScheme,
+    {
+        assert!(matches!(
+            T::aggregate(0, &[]),
+            Err(ThresholdError::ZeroThreshold)
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Fixes two input-validation defects in Shamir-share recovery, both reachable from the `combine` entry points in `crates/threshold-bls-ffi/src/wasm.rs` and `crates/threshold-bls-ffi/src/ffi.rs` with caller-supplied partials.

**Duplicate share indices.** `share_map` (`crates/threshold-bls/src/poly.rs`) chose the interpolation subset with `take(t)` before the `BTreeMap` fold deduplicated indices, so duplicates shrank the set below `t`. Release builds silently interpolated over too few points and `aggregate` returned a wrong signature; debug builds panicked on the `debug_assert_eq!`. Fixed by sorting, deduping by index (stable sort, so the caller's first share per index wins deterministically), and only then requiring `t` distinct points. A benign duplicate — the same partial submitted twice — now counts as one evaluation point instead of poisoning the recovery: indices `[0,0,1,2,3]` with `t=4` recover, while `[0,0,1,2]` with `t=4` is rejected with `InvalidRecovery(3, 4)` instead of producing a wrong signature.

**Zero threshold.** `aggregate(0, &[])` passed both length guards (`0 > 0` and `0 < 0` are false) and interpolated over an empty share set, which folds to the group identity — a valid-looking signature from no inputs at all. Now rejected via new `ZeroThreshold` error variants, both in `share_map` (covering `recover` and `full_recover`) and at the top of `aggregate` so the signature layer reports it directly.

For well-formed input the chosen subset and the produced signature are byte-identical to before; only defective inputs change behavior, from a silent wrong answer or panic to an explicit error. No binding changes needed: wasm `combine` surfaces the new variants through `Display`, the C ABI `combine` keeps returning `false` on any error.

Verified: `cargo test --workspace --all-features` (55 tests + 7 doctests), `just lint`, `just fmt`, and the new tests additionally pass under `--release` — the fix removes the debug/release behavior split, so the regular test profile now pins both halves. The `interpolation` proptest range moves from `0..100` to `1..100` because `num_evals = 0` is now correctly an error; that case has a dedicated test instead.