### PR TITLE
ci: Let Dependabot open PRs for the npm dev dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  # The npm package's jest/babel toolchain in bindings/js. Rust crates are
+  # deliberately not listed here: Renovate already manages them.
+  - package-ecosystem: npm
+    directory: /bindings/js
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Adds a minimal `.github/dependabot.yml` covering the npm ecosystem in `bindings/js`, weekly. Until now the jest/babel lockfile was only covered by security alerts with no automated PRs — the five alerts closed by #207 had been sitting since they were filed. Rust crates are deliberately left out: Renovate already manages them, and doubling up would file duplicate PRs against the known-stuck rand 0.8 upgrade.

Config-only change; takes effect once merged to the default branch. GitHub validates the file on merge, so there is nothing to run locally — the syntax matches the documented two-key minimum (ecosystem + directory + schedule).