### PR TITLE
Remaining correctness fixes from the security review

### DIFF
--- a/crates/threshold-bls-ffi/src/wasm.rs
+++ b/crates/threshold-bls-ffi/src/wasm.rs
@@ -86,11 +86,15 @@ pub fn verify(public_key_buf: &[u8], message: &[u8], signature: &[u8]) -> Result
 }
 
 #[wasm_bindgen(js_name = verifyBlindSignature)]
-/// Verifies the signature after it has been unblinded without hashing. Users will call this on the
-/// threshold signature against the full public key
+/// Verifies a signature over a message that is already a serialized group
+/// point (e.g. a blinded message), without hashing it to the curve.
+///
+/// Note that this only proves the signature was produced over the given
+/// point. It says nothing about the plaintext that was blinded — use
+/// `verify` on the unblinded signature and plaintext for that.
 ///
 /// * public_key: The public key used to sign the message
-/// * message: The message which was signed
+/// * message: The serialized group point which was signed
 /// * signature: The signature which was produced on the message
 ///
 /// # Throws
@@ -104,7 +108,7 @@ pub fn verify_blind_signature(
     let public_key: PublicKey = serialization::deserialize(public_key_buf)
         .map_err(|err| JsValue::from_str(&format!("could not deserialize public key {}", err)))?;
 
-    // checks the signature on the message hash
+    // checks the pairing against the message point directly, without hashing
     SigScheme::blind_verify(&public_key, message, signature)
         .map_err(|err| JsValue::from_str(&format!("signature verification failed: {}", err)))
 }

--- a/crates/threshold-bls/src/curve/bls12377.rs
+++ b/crates/threshold-bls/src/curve/bls12377.rs
@@ -33,6 +33,8 @@ pub enum BLSError {
     HashToCurveError,
     #[error("domain length is too large: {0}")]
     DomainTooLarge(usize),
+    #[error("hash output size is too large: {0}")]
+    OutputSizeTooLarge(usize),
 }
 
 /// Encodes the XOF digest length into the node offset field used by Blake2s/Blake2x.
@@ -51,6 +53,11 @@ fn blake2_hash(
 ) -> Result<Vec<u8>, BLSError> {
     if domain.len() > 8 {
         return Err(BLSError::DomainTooLarge(domain.len()));
+    }
+    // The XOF digest length is encoded into a 16-bit node offset field;
+    // larger outputs would silently truncate in xof_digest_length_to_node_offset.
+    if output_size_in_bytes > u16::MAX as usize {
+        return Err(BLSError::OutputSizeTooLarge(output_size_in_bytes));
     }
 
     // CRH step: compress the message with Blake2s
@@ -227,6 +234,11 @@ impl Element for G1 {
 /// - Checks bit 7 (`& 0x80`) of the last hash byte for the y-sign (positive = largest y)
 /// - Parses x via `Field::from_random_bytes` (masks last byte to field bits)
 /// - Never rejects based on the infinity flag in random hash bytes
+///
+/// Subgroup soundness: `mul_by_cofactor_to_group` maps an on-curve point into
+/// the prime-order subgroup only because `gcd(cofactor, r) = 1`, which holds
+/// for both groups of BLS12-377. Any curve added here must satisfy the same
+/// precondition.
 fn try_and_increment_hash<P: SWCurveConfig>(
     domain: &[u8],
     message: &[u8],
@@ -259,6 +271,9 @@ where
             if let Some(p) = Affine::<P>::get_point_from_x_unchecked(x, is_positive) {
                 let scaled = p.mul_by_cofactor_to_group();
                 if !scaled.is_zero() {
+                    debug_assert!(scaled
+                        .into_affine()
+                        .is_in_correct_subgroup_assuming_on_curve());
                     return Ok(scaled);
                 }
             }
@@ -595,6 +610,14 @@ mod tests {
             .unwrap();
             assert_eq!(hex::encode(&bytes), *expected_hex);
         }
+    }
+
+    #[test]
+    fn blake2_hash_rejects_oversized_output() {
+        assert!(matches!(
+            blake2_hash(b"", b"some message", u16::MAX as usize + 1),
+            Err(BLSError::OutputSizeTooLarge(_))
+        ));
     }
 
     #[test]

--- a/crates/threshold-bls/src/curve/bls12377.rs
+++ b/crates/threshold-bls/src/curve/bls12377.rs
@@ -623,4 +623,34 @@ mod tests {
             assert_eq!(hex::encode(&serialized), *expected_hex);
         }
     }
+
+    // The expected values pin this implementation's outputs, so a dependency
+    // upgrade that changes G2 hashing breaks this test instead of silently
+    // breaking interoperability with existing signatures.
+    #[test]
+    fn hash_to_curve_g2() {
+        use crate::group::Point;
+
+        let cases: &[(&[u8], &str)] = &[
+            (
+                &[0x00; 32],
+                "1f2855c5b9542908843dfb8f63966a863f63a0ea776bae7236ce6dfbb6ad676094e7428c79e590eef168d309b1e95801526da75adb79f16fd3b2f8c7913cb48cf11e0fdca3282a7cf78311bc56b0b84b1162cd019751605868902ad42c792c00",
+            ),
+            (
+                &[0x56; 32],
+                "cd55c00b0849fb761f26af4f900326b7a8cf6cc9bca6b424d8f256b9b268730740cba529e5cca4545da16f88fab505016f33e6df55ce89cde7ecda4b9be06472403fdd2f9e6b4c4fb6c38a6b452125f7ca2d08b5611620a0caafb13cd67d7f01",
+            ),
+            (
+                &[0xab; 32],
+                "0daef0086d6cb937913cc40c28a07b4fb47c12dabd135df517293729abca81d82dd6070583b165a4e68dbb90467d2c0088b26681bcf0775280eb5befdacdc41480037bbd1b00e10ef2f9c12b04476c16fb95287da8799a6104b413af08e35581",
+            ),
+        ];
+
+        for (msg, expected_hex) in cases {
+            let mut point = G2::new();
+            point.map(msg).expect("hash to curve failed");
+            let serialized = bincode::serialize(&point).unwrap();
+            assert_eq!(hex::encode(&serialized), *expected_hex);
+        }
+    }
 }


### PR DESCRIPTION
Closes out the remaining low-severity correctness items from the security review (finding 7/8), now that the higher-priority ones landed in #205 and #206.

- **G2 known-answer vectors**: only G1 hashing was anchored by test vectors, so a dependency upgrade changing G2 hash-to-curve would have silently broken interoperability with existing `G1Scheme` signatures. The new vectors pin the current implementation's outputs.
- **`blake2_hash` output-size guard**: the XOF digest length is packed into a 16-bit field and silently truncated above `u16::MAX`. Unreachable with current callers (they only hash to point-sized outputs), so this is defense in depth; comes with a test for the new error.
- **`try_and_increment_hash`**: documents the `gcd(cofactor, r) = 1` precondition its cofactor clearing relies on, plus a `debug_assert` that the returned point is in the prime-order subgroup.
- **`verifyBlindSignature` docs**: the wasm doc claimed it "checks the signature on the message hash"; it actually pairs against the given message point without hashing and proves nothing about the blinded plaintext.

No wire-format or behavior changes for valid inputs. Verified with `cargo test --workspace --all-features` (doctests included), `just lint`, `just fmt`.