### PR TITLE
ci: Run the doctests

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -18,6 +18,10 @@ jobs:
       - uses: taiki-e/install-action@nextest
       - name: cargo test
         run: cargo nextest run --workspace --all-features
+      # nextest does not run doctests, and they are the crate's primary usage
+      # documentation, so they need their own invocation.
+      - name: cargo test --doc
+        run: cargo test --locked --workspace --all-features --doc
 
   cargo-lint:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,8 +19,10 @@ cargo test -p threshold-bls poly::      # single test / module filter
 ```
 
 - CI (`.github/workflows/rust_ci.yml`) runs `cargo nextest run --workspace
-  --all-features`. nextest does not run doctests — the doctests in
-  `threshold-bls/src/lib.rs` only execute under plain `cargo test`.
+  --all-features`, then `cargo test --doc` as a second step. nextest does not
+  run doctests, so anything that only executes under plain `cargo test` — the
+  doctests in `threshold-bls/src/lib.rs` and `sig/sig.rs` — needs that step to
+  be covered.
 - `just test` (and `just test-cached`, which adds cargo/target cache volumes)
   runs `cargo test --features wasm` inside the linux/amd64 Docker build image —
   the same environment the released libraries are built in. Requires Docker.


### PR DESCRIPTION
`cargo nextest run` is the only test invocation any pipeline makes, and nextest
does not run doctests — nexte.st says so itself: "Doctests are currently not
supported because of limitations in stable Rust. For now, run doctests in a
separate step with `cargo test --doc`." The flag does not exist:
`cargo nextest run --doc` fails with `unexpected argument '--doc' found`.

So the seven examples in `lib.rs` and `sig/sig.rs` — the crate's primary usage
documentation, the first thing an integrator copies — were executed by nobody.
`CLAUDE.md` documented the trap without closing it.

This adds the second step to the existing test job and updates that CLAUDE.md
note.

### Verified

They pass as they stand (7 passed, 0 failed), so the step goes green on merge.

That a step exists proves nothing about whether it catches anything, so I broke
one — swapping `SignatureScheme` in the first `lib.rs` example for a name that
does not exist:

| command | result |
|---|---|
| `cargo nextest run --workspace --all-features` | 84 tests run: 84 passed |
| `cargo test --locked --workspace --all-features --doc` | FAILED. 6 passed; 1 failed |

That is the gap this closes, in one line.

Item 2 of the maintainability review, §3.