### PR TITLE
ffi: Run the C smoke test under AddressSanitizer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,11 +123,14 @@ result; `just install-cbindgen` provides the pinned version it insists on.
 
 CI enforces this twice over. `just check-header` regenerates, compiles the
 header as C11, C99, C++, Objective-C and Objective-C++, and fails on drift.
-`just check-abi` compiles `cross/smoke_test.c` against it, links the cdylib and
-runs it, then diffs the exported symbols against
-`cross/exported-symbols.txt`. The second is what catches a header that
+`just check-abi` compiles `cross/smoke_test.c` against it under
+AddressSanitizer, links the cdylib and runs it, then diffs the exported symbols
+against `cross/exported-symbols.txt`. The second is what catches a header that
 disagrees with the library; Rust tests call Rust functions with Rust types and
-structurally cannot.
+structurally cannot. Only the C side is instrumented, but the allocator is
+shared, so a buffer the library hands out is tracked: reading past its end, or
+freeing it twice, fails the run. Leak checking is pinned off — the
+uninstrumented Rust side's one-time allocations would swamp it.
 
 Three things constrain how the header can be generated, all of them learned the
 hard way:

--- a/crates/threshold-bls-ffi/src/ffi.rs
+++ b/crates/threshold-bls-ffi/src/ffi.rs
@@ -949,14 +949,14 @@ mod tests {
         let (message_to_sign, blinding_factor) = if should_blind {
             let mut blinded_message = MaybeUninit::<Buffer>::uninit();
             let mut blinding_factor = MaybeUninit::<*mut BlindingFactor>::uninit();
-            unsafe {
+            assert!(unsafe {
                 blind(
                     &Buffer::from(msg.as_ref()),
                     &Buffer::from(user_seed),
                     blinded_message.as_mut_ptr(),
                     blinding_factor.as_mut_ptr(),
                 )
-            };
+            });
             let blinded_message = unsafe { blinded_message.assume_init() };
             let blinding_factor = unsafe { &*blinding_factor.assume_init() };
 
@@ -1051,14 +1051,14 @@ mod tests {
         let (message_to_sign, blinding_factor) = if should_blind {
             let mut blinded_message = MaybeUninit::<Buffer>::uninit();
             let mut blinding_factor = MaybeUninit::<*mut BlindingFactor>::uninit();
-            unsafe {
+            assert!(unsafe {
                 blind(
                     &Buffer::from(msg.as_ref()),
                     &Buffer::from(user_seed),
                     blinded_message.as_mut_ptr(),
                     blinding_factor.as_mut_ptr(),
                 )
-            };
+            });
             let blinded_message = unsafe { blinded_message.assume_init() };
             let blinding_factor = unsafe { &*blinding_factor.assume_init() };
 

--- a/justfile
+++ b/justfile
@@ -276,11 +276,24 @@ check-abi:
 
     # The cdylib rather than the staticlib: linking a Rust staticlib from C
     # means supplying Rust's native system libraries by hand.
+    #
+    # AddressSanitizer is what makes the run worth more than the compile. The
+    # library hands C raw pointers and lengths, and reading one byte past a
+    # buffer it returned passes silently otherwise — verified by doing exactly
+    # that. Only the C side is instrumented, but the allocator is shared, so
+    # every buffer the library hands over is tracked.
     clang -std=c11 -Wall -Wextra -Werror \
+        -fsanitize=address -fno-omit-frame-pointer -g \
         -I "$cross" "$cross/smoke_test.c" \
         -L {{ target_dir }}/release -lblind_threshold_bls \
         -o "$tmp/smoke_test"
-    LD_LIBRARY_PATH={{ target_dir }}/release \
+    # Leak checking is off deliberately, and pinned rather than left to the
+    # platform: it defaults on under Linux and is unsupported on arm64 macOS, and
+    # the uninstrumented Rust side's one-time allocations would be reported as
+    # leaks no C caller can free. What is left is the ownership class this test
+    # exists for — overflow, use after free, double and invalid free.
+    ASAN_OPTIONS=detect_leaks=0 \
+        LD_LIBRARY_PATH={{ target_dir }}/release \
         DYLD_LIBRARY_PATH={{ target_dir }}/release \
         "$tmp/smoke_test"
 


### PR DESCRIPTION
`just check-abi` compiled the C smoke test and ran it, but the run added almost
nothing the compile had not already proved. Reading one byte past a buffer
`serialize_pubkey` handed back — the ownership class this test exists for — passed
with exit 0.

Measured, on the recipe as it stands today versus this branch:

| sabotage | before | after |
|---|---|---|
| read 1 byte past a returned buffer | passes, exit 0 | `heap-buffer-overflow … smoke_test.c:184 in serialization`, recipe fails 134 |
| `free_vector` the same buffer twice | crashes, exit 133, no diagnosis | `attempting double-free … in plain_signing` |

Only the C side is instrumented — the Rust library is built as usual — but the
allocator is shared, so every buffer that crosses the boundary is tracked.

### Leak checking is pinned off

`ASAN_OPTIONS=detect_leaks=0`, set explicitly rather than left to the platform:
Linux defaults it on, arm64 macOS reports `detect_leaks is not supported on this
platform`, so the default means two different gates. The Rust side is not
instrumented and its one-time allocations would be reported as leaks no C caller
can free. What remains is overflow, use after free, double free and invalid free,
which is the class the C surface can actually get wrong. Worth revisiting if the
library ever gets built with `-Zsanitizer`.

### Also in here

The two `ffi.rs` tests that called `unsafe { blind(…) };` and then
`assume_init()` regardless now assert on the `bool`. #217 made every other call
site check its return; these two were the outliers.

### Verified

`just check-abi` passes, and fails as shown above when the smoke test overreads
by one byte — checked against the committed recipe, not a scratch copy. 85 tests,
7 doctests, `just lint`, `just fmt`, `just check-header` all clean.

Item 11 of the maintainability review.