### PR TITLE
docs: Correct the rustdoc that describes code it no longer matches

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -22,6 +22,12 @@ jobs:
       # documentation, so they need their own invocation.
       - name: cargo test --doc
         run: cargo test --locked --workspace --all-features --doc
+      # The rustdoc is the API documentation consumers read. Nothing checked it,
+      # which is how links to a trait renamed years ago survived.
+      - name: cargo doc
+        run: cargo doc --locked --no-deps --all-features
+        env:
+          RUSTDOCFLAGS: -D warnings
 
   cargo-lint:
     runs-on: ubuntu-latest

--- a/crates/threshold-bls-ffi/src/wasm.rs
+++ b/crates/threshold-bls-ffi/src/wasm.rs
@@ -246,7 +246,7 @@ pub fn partial_verify_blind_signature(
 #[wasm_bindgen]
 /// Combines a flattened vector of partial signatures to a single threshold signature
 ///
-/// NOTE: Wasm-bindgen does not support Vec<Vec<u8>>, so this function accepts a flattened
+/// NOTE: Wasm-bindgen does not support `Vec<Vec<u8>>`, so this function accepts a flattened
 /// byte vector which it will parse in chunks for each signature.
 ///
 /// NOTE: If you are working with an array of Uint8Arrays In Javascript, the simplest

--- a/crates/threshold-bls/src/group.rs
+++ b/crates/threshold-bls/src/group.rs
@@ -5,17 +5,23 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display};
 use std::marker::PhantomData;
 
-/// Element represents an element of a group with the additive notation
-/// which is also equipped with a multiplication transformation.
+/// Element represents an element of a group which is also equipped with a
+/// multiplication transformation.
 /// Two implementations are for Scalar which forms a ring so RHS is the same
 /// and Point which can be multiplied by a scalar of its prime field.
+///
+/// The method names are additive — `add`, `zero` — because the groups this was
+/// written for are written that way. `GT` is not: its `add` multiplies and its
+/// `new`/`zero` is the multiplicative identity, so read every name below as the
+/// group operation rather than as arithmetic.
 pub trait Element:
     Clone + Display + Debug + Eq + Serialize + for<'a> Deserialize<'a> + PartialEq + Send + Sync
 {
     /// The right-hand-side argument for multiplication
     type RHS;
 
-    /// Returns the zero element of the group
+    /// Returns the identity element of the group operation: zero where the group
+    /// is written additively, one for `GT`
     fn new() -> Self;
 
     /// Returns the one element of the group
@@ -30,7 +36,8 @@ pub trait Element:
     /// Samples a random element using the provided RNG
     fn rand<R: RngCore>(rng: &mut R) -> Self;
 
-    /// Returns the zero element of the group
+    /// Alias for [`Element::new`], and identical to it — including for `GT`,
+    /// where it returns the multiplicative identity rather than a zero
     fn zero() -> Self {
         Self::new()
     }
@@ -65,7 +72,7 @@ pub trait Curve: Clone + Debug + Send + Sync {
     /// The curve's point
     type Point: Point<RHS = Self::Scalar>;
 
-    /// scalar returns the identity element of the field.
+    /// scalar returns the field's additive identity, zero.
     fn scalar() -> Self::Scalar {
         Self::Scalar::new()
     }

--- a/crates/threshold-bls/src/lib.rs
+++ b/crates/threshold-bls/src/lib.rs
@@ -23,7 +23,7 @@
 //! Blind signatures are supported via an implementation based on this
 //! [paper](https://eprint.iacr.org/2018/733.pdf).
 //!
-//! The procedure is the same, but we import the [`SignatureSchemeExt`] because it requires
+//! The procedure is the same, but we import the [`BlindScheme`](sig::BlindScheme) because it requires
 //! signing the blinded message without hashing it. Note that verification is done in the same
 //! way as before on the unblinded signature and message.
 //!
@@ -117,11 +117,11 @@
 //! ### Supporting a new curve
 //!
 //! Curves are implemented in the [`curve`] module. In order to support a new curve,
-//! the trait [`PairingCurve`] must be implemented for it. This in turn requires that
+//! the trait [`PairingCurve`](group::PairingCurve) must be implemented for it. This in turn requires that
 //! you define the pairing-friendly curve's `Scalar` and `G_T` fields, its
 //! G1 and G2 groups and implement the `Scalar`, `Element` and `Point` traits for them.
-//! For reference, use the [existing implementation of BLS12-377](bls12_377) which wraps the implementation
-//! from [Zexe](https://github.com/arkworks-rs/snark/).
+//! For reference, use the [existing implementation of BLS12-377](curve::bls12377), which wraps
+//! [arkworks](https://github.com/arkworks-rs/algebra).
 //!
 //! ### Switching Groups
 //!
@@ -131,28 +131,26 @@
 //! Before:
 //!
 //! ```rust
-//! use threshold_bls::sig::G1Scheme as SigScheme;
+//! use threshold_bls::schemes::bls12_377::G1Scheme as SigScheme;
 //! ```
 //!
 //! After:
 //!
 //! ```rust
-//! use threshold_bls::sig::G2Scheme as SigScheme;
+//! use threshold_bls::schemes::bls12_377::G2Scheme as SigScheme;
 //! ```
 //!
-//! ## Features
+//! The name says which group holds the public keys; signatures live in the other
+//! one. [`sig::G1Scheme`] and [`sig::G2Scheme`] are the same schemes still generic
+//! over the pairing curve, so they take a curve parameter and do not substitute
+//! into the examples above.
 //!
-//! Curently there is `BLS12-377` available.
+//! ## Curves
 //!
-//! ```toml
-//! threshold-bls = { version = "0.1" }
-//! ```
-//!
-//! [poly]: ./poly/index.html
-//! [bls12_377]: ./curve/zexe/index.html
-//!
-//! [`curve`]: ./curve/index.html
-//! [`SignatureSchemeExt`]: ./sig/trait.SignatureSchemeExt.html
+//! `BLS12-377` is the only curve implemented, in [`curve::bls12377`]; the schemes
+//! instantiated over it are in [`schemes::bls12_377`]. The crate has no Cargo
+//! features and is not published to crates.io, so consumers depend on it by git
+//! revision.
 
 /// Curve implementations for the traits defined in the [`group`](group/index.html) module.
 pub mod curve;
@@ -160,9 +158,9 @@ pub mod curve;
 /// Definitions of generic traits with scalars of prime fields and points on elliptic curves.
 pub mod group;
 
-/// Implementation of a polynomial suitable to be used for secret sharing schemes and DKG
-/// protocols. It can evaluate and interpolate private and public shares to their corresponding
-/// polynomial.
+/// Implementation of a polynomial suitable to be used for secret sharing schemes.
+/// It can evaluate and interpolate private and public shares to their
+/// corresponding polynomial.
 pub mod poly;
 
 /// Bounded bincode (de)serialization helpers that cap input size to prevent

--- a/crates/threshold-bls/src/poly.rs
+++ b/crates/threshold-bls/src/poly.rs
@@ -26,6 +26,11 @@ impl<A: fmt::Display> fmt::Display for Eval<A> {
 /// the type of the variable, which is always a scalar.
 ///
 /// Always has at least one coefficient, on the wire as well as in memory.
+///
+/// Deserializing one goes through [`serialization::deserialize`](crate::serialization::deserialize),
+/// so a polynomial larger than [`MAX_DESERIALIZE_BYTES`](crate::serialization::MAX_DESERIALIZE_BYTES)
+/// is refused rather than allocated. At 1 MiB that is a ceiling on the number of
+/// participants, in the order of ten thousand.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(try_from = "Vec<C>")]
 pub struct Poly<C>(Vec<C>);

--- a/crates/threshold-bls/src/sig/blind.rs
+++ b/crates/threshold-bls/src/sig/blind.rs
@@ -10,8 +10,9 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum BlindError {
     /// InvalidToken is thrown out when the token used to unblind can not be
-    /// inversed. This error should not happen if you use the Token that was
-    /// returned by the blind operation.
+    /// inversed. A token returned by the blind operation always can be; a
+    /// default-constructed one never can, since [`Token::new`] holds the zero
+    /// scalar.
     #[error("invalid token")]
     InvalidToken,
 

--- a/crates/threshold-bls/src/sig/sig.rs
+++ b/crates/threshold-bls/src/sig/sig.rs
@@ -115,9 +115,10 @@ pub trait BlindScheme: Scheme {
         rng: &mut R,
     ) -> Result<(Self::Token, Vec<u8>), Self::Error>;
 
-    /// Given the blinding factor that was used to blind the provided message, it will
-    /// unblind it and return the cleartext message
-    fn unblind_sig(t: &Self::Token, blinded_message: &[u8]) -> Result<Vec<u8>, Self::Error>;
+    /// Given the blinding factor that was used to blind the message, removes it from
+    /// a signature over that blinded message, returning the signature over the
+    /// cleartext. It takes and returns a signature, never the message.
+    fn unblind_sig(t: &Self::Token, blinded_signature: &[u8]) -> Result<Vec<u8>, Self::Error>;
 
     /// blind_sign is the method that signs the given blinded message and
     /// returns a blinded signature.

--- a/crates/threshold-bls/src/sig/tbls.rs
+++ b/crates/threshold-bls/src/sig/tbls.rs
@@ -9,7 +9,9 @@ use thiserror::Error;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 /// A private share which is part of the threshold signing key
 pub struct Share<S> {
-    /// The share's index in the polynomial
+    /// Identifies the share's holder. It is not the x-coordinate the polynomial
+    /// is evaluated at: that is `index + 1`, since evaluating at zero would hand
+    /// out the secret itself.
     pub index: Idx,
     /// The scalar corresponding to the share's secret
     pub private: S,

--- a/justfile
+++ b/justfile
@@ -209,8 +209,10 @@ fmt:
 install-cbindgen:
     cargo install cbindgen --version {{ cbindgen_version }} --locked
 
-# Regenerate cross/threshold.h from ffi.rs. Run after any change to the C ABI
-# and commit the result; `check-header` fails if it is stale.
+# Run after any change to the C ABI and commit the result; `check-header` fails
+# if the committed copy is stale.
+
+# Regenerate cross/threshold.h from ffi.rs
 generate-header:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -228,10 +230,10 @@ generate-header:
     cd {{ justfile_directory() }}/crates/threshold-bls-ffi
     cbindgen --output cross/threshold.h
 
-# Regenerate the header, compile it in every dialect a consumer might use, and
-# fail if the committed copy is stale. Compiling matters as much as the diff: a
-# malformed header committed alongside the source that produced it would pass a
-# diff-only check.
+# Compiling matters as much as the diff: a malformed header committed alongside
+# the source that produced it would pass a diff-only check.
+
+# Regenerate threshold.h, compile it in every dialect a consumer might use, and fail if it is stale
 check-header: generate-header
     #!/usr/bin/env bash
     set -euo pipefail
@@ -259,12 +261,11 @@ check-header: generate-header
     git ls-files --error-unmatch -- "$inc/threshold.h" > /dev/null
     git diff --exit-code -- "$inc/threshold.h"
 
-# Compile the C smoke test against the generated header, link it to the real
-# library, run it, and check the exported symbols against the manifest.
-#
 # Rust tests call Rust functions with Rust types, so they cannot catch a
-# header/library mismatch — which is how the keygen declaration stayed wrong
-# for five years. This can.
+# header/library mismatch — which is how the keygen declaration stayed wrong for
+# five years. This can.
+
+# Compile the C smoke test against the header, run it under ASan, and check the exported symbols
 check-abi:
     #!/usr/bin/env bash
     set -euo pipefail


### PR DESCRIPTION
The crate documentation had drifted from the code, and nothing checked it. This
corrects §10's rustdoc findings and adds the gate that would have caught half of
them.

### The gate found more than the review did

`RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` on `main`:

```
error: unresolved link to `PairingCurve`   lib.rs:120
error: unresolved link to `bls12_377`      lib.rs:123
error: unclosed HTML tag `u8`              wasm.rs:249   (Vec<Vec<u8>> in prose)
```

None were in the review. Meanwhile the two links the review *did* list —
`SignatureSchemeExt` and `curve/zexe` — did **not** error, because they were
written as URL definitions rather than intra-doc links, which rustdoc cannot
check. Converting them is what puts them under the lint. That asymmetry is the
argument for the CI step: a link that rots silently is the normal case.

### Docs that contradicted their code

- `Element::new`/`zero` said "the zero element of the group". `GT::new()` returns
  `One::one()`, so `GT::zero() == GT::one()` is `true`, and `GT::add` multiplies.
  The trait header claimed additive notation for all of them. Documented as the
  identity of the group operation, with `GT` called out. **Left as a docs fix on
  purpose** — changing `GT::new()` is an API break, and it belongs with item 17's
  `new`/`zero` rename discussion.
- `Curve::scalar()` "returns the identity element of the field" — it returns
  zero, the additive identity, while `point()` returns the generator.
- `unblind_sig` documented its parameter as `blinded_message` and its return as
  "the cleartext message". It takes and returns a *signature*.
- `BlindError::InvalidToken` said it "should not happen if you use the Token that
  was returned by the blind operation" — true, but `Token::new()` and its
  `Default` are public and hold the zero scalar, which has no inverse, so they
  always produce it.
- `Share::index` was "the share's index in the polynomial". It identifies the
  holder; the polynomial is evaluated at `index + 1`, because evaluating at zero
  would hand out the secret.

### Stale rather than wrong

- "Switching Groups" told readers to `use threshold_bls::sig::G1Scheme`, which is
  generic over the pairing curve and does not substitute into the examples above
  it. It now names `schemes::bls12_377`, as those examples do, and says what the
  `sig` versions are for.
- "Features" advertised `threshold-bls = { version = "0.1" }` against a 0.2.0
  crate with no `[features]` section that is not published to crates.io.
- `poly` described itself as being for "DKG protocols", removed in `a911f40`.
- `Poly` now points at `MAX_DESERIALIZE_BYTES`, which is an undocumented ceiling
  on participant count from the caller's side.
- `just --list` showed `check-abi  # for five years. This can.` — just takes the
  last comment line as the doc string, so the three header recipes now keep their
  explanation in a block above a blank line.

### Verified

`cargo doc -D warnings` clean, 85 tests, 7 doctests (the two edited examples are
doctests and still compile), `just lint`, `just fmt`, `just check-header`,
`just check-abi`.

No changelog entry: documentation corrections, no API, behaviour or artifact
change.

Item 16 of the maintainability review.